### PR TITLE
Fix runtime bugs

### DIFF
--- a/examples/00_load/load_bench.py
+++ b/examples/00_load/load_bench.py
@@ -93,7 +93,7 @@ def parse_args():
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
     parser.add_argument("-d", "--validate", action="store_true", help="Enable validation output")
 
-    parser.add_argument("-p", "--heap_size", type=int, default=1 << 34, help="Iris heap size")
+    parser.add_argument("-p", "--heap_size", type=int, default=1 << 33, help="Iris heap size")
     parser.add_argument("-o", "--output_file", type=str, default="", help="Output file")
     parser.add_argument("-n", "--num_experiments", type=int, default=10, help="Number of experiments")
     parser.add_argument("-w", "--num_warmup", type=int, default=1, help="Number of warmup iterations")
@@ -240,7 +240,7 @@ def main():
     element_size_bytes = torch.tensor([], dtype=dtype).element_size()
     source_buffer = shmem.ones(args["buffer_size"] // element_size_bytes, device="cuda", dtype=dtype)
     result_buffer = shmem.zeros_like(source_buffer)
-    
+
     for source_rank in range(num_ranks):
         for destination_rank in range(num_ranks):
             bandwidth_gbps = bench_load(

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -122,7 +122,9 @@ class Iris:
         new_tensor.zero_()
         return new_tensor
 
-    def arange(self, start=0, end=None, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False):
+    def arange(
+        self, start=0, end=None, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False
+    ):
         """
         Returns a 1-D tensor of size ⌈(end - start) / step⌉ with values from the interval [start, end)
         taken with common difference step beginning from start.
@@ -290,9 +292,13 @@ class Iris:
 
     def __throw_if_invalid_output_tensor(self, tensor: torch.Tensor, num_elements: int, dtype: torch.dtype):
         if not self.__tensor_on_device(tensor):
-            raise RuntimeError(f"The output tensor is not on the same device as the Iris instance. The Iris instance is on device {self.device} but the output tensor is on device {tensor.device}")
+            raise RuntimeError(
+                f"The output tensor is not on the same device as the Iris instance. The Iris instance is on device {self.device} but the output tensor is on device {tensor.device}"
+            )
         if not self.__on_symmetric_heap(tensor):
-            raise RuntimeError(f"The output tensor is not on the symmetric heap. The Iris instance is on heap base {self.heap_bases[self.cur_rank]} but the output tensor is on heap base {tensor.data_ptr()}")
+            raise RuntimeError(
+                f"The output tensor is not on the symmetric heap. The Iris instance is on heap base {self.heap_bases[self.cur_rank]} but the output tensor is on heap base {tensor.data_ptr()}"
+            )
         if tensor.numel() != num_elements:
             raise RuntimeError(f"The output tensor has {tensor.numel()} elements, but {num_elements} are required")
         if tensor.dtype != dtype:
@@ -302,7 +308,11 @@ class Iris:
         return tensor.device == self.device
 
     def __on_symmetric_heap(self, tensor: torch.Tensor):
-        return tensor.data_ptr() >= self.heap_bases[self.cur_rank] and tensor.data_ptr() < self.heap_bases[self.cur_rank] + self.heap_size
+        return (
+            tensor.data_ptr() >= self.heap_bases[self.cur_rank]
+            and tensor.data_ptr() < self.heap_bases[self.cur_rank] + self.heap_size
+        )
+
 
 @triton.jit
 def translate(src_ptr, cur_rank, target_rank, heap_bases, debug=False):

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -122,7 +122,7 @@ class Iris:
         new_tensor.zero_()
         return new_tensor
 
-    def arange(self, start=0, end=None, step=1, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False):
+    def arange(self, start=0, end=None, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False):
         """
         Returns a 1-D tensor of size ⌈(end - start) / step⌉ with values from the interval [start, end) 
         taken with common difference step beginning from start.

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -124,7 +124,7 @@ class Iris:
 
     def arange(self, start=0, end=None, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False):
         """
-        Returns a 1-D tensor of size ⌈(end - start) / step⌉ with values from the interval [start, end) 
+        Returns a 1-D tensor of size ⌈(end - start) / step⌉ with values from the interval [start, end)
         taken with common difference step beginning from start.
 
         Args:

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -126,7 +126,7 @@ class Iris:
         """
         Returns a 1-D tensor of size ⌈(end - start) / step⌉ with values from the interval [start, end) 
         taken with common difference step beginning from start.
-        
+
         Args:
             start (Number, optional): the starting value for the set of points. Default: 0.
             end (Number): the ending value for the set of points
@@ -138,28 +138,27 @@ class Iris:
             requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: False.
         """
         self.log_debug(f"arange: start = {start}, end = {end}, step = {step}, dtype = {dtype}")
-        
+
         # Handle the case where only one argument is provided (end)
         if end is None:
             end = start
             start = 0
-            
         # Calculate the number of elements
         num_elements = math.ceil((end - start) / step)
-        
         # Infer dtype if not provided
         if dtype is None:
             if any(isinstance(x, float) for x in [start, end, step]):
                 dtype = torch.get_default_dtype()
             else:
                 dtype = torch.int64
-                
-        tensor = self.allocate(num_elements=num_elements, dtype=dtype)
+        if out is not None:
+            self.__throw_if_invalid_output_tensor(out, num_elements, dtype)
+            tensor = out
+        else:
+            tensor = self.allocate(num_elements=num_elements, dtype=dtype)
         tensor[:] = torch.arange(start, end, step, dtype=dtype, device="cuda")
-        
         if requires_grad:
             tensor.requires_grad_()
-            
         return tensor
 
     def zeros(self, *size, dtype=torch.int, device=None, requires_grad=False, **kwargs):
@@ -192,11 +191,40 @@ class Iris:
             tensor.requires_grad_()
         return tensor.reshape(size)
 
-    def ones(self, *size, dtype=torch.int):
-        self.log_debug(f"ones: size = {size}, dtype = {dtype}")
+    def ones(self, *size, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False):
+        """
+        Returns a tensor filled with the scalar value 1, with the shape defined by the variable argument size.
+
+        Args:
+            *size (int...): a sequence of integers defining the shape of the output tensor. Can be a variable number of arguments or a collection like a list or tuple.
+
+        Keyword Arguments:
+            out (Tensor, optional): the output tensor.
+            dtype (torch.dtype, optional): the desired data type of returned tensor. Default: if None, uses a global default (see torch.set_default_dtype()).
+            layout (torch.layout, optional): the desired layout of returned Tensor. Default: torch.strided.
+            device (torch.device, optional): the desired device of returned tensor. Default: if None, uses the current device for the default tensor type.
+            requires_grad (bool, optional): If autograd should record operations on the returned tensor. Default: False.
+        """
+        self.log_debug(f"ones: size = {size}, dtype = {dtype}, device = {device}, requires_grad = {requires_grad}")
+
+        # Handle the case where size is provided as a single tuple/list
+        if len(size) == 1 and isinstance(size[0], (tuple, list)):
+            size = size[0]
+
+        # Use global default dtype if None is provided
+        if dtype is None:
+            dtype = torch.get_default_dtype()
         size, num_elements = self.parse_size(size)
-        tensor = self.allocate(num_elements=num_elements, dtype=dtype)
+
+        # If out is provided, use it; otherwise allocate new tensor
+        if out is not None:
+            self.__throw_if_invalid_output_tensor(out, num_elements, dtype)
+            tensor = out
+        else:
+            tensor = self.allocate(num_elements=num_elements, dtype=dtype)
         tensor.fill_(1)
+        if requires_grad:
+            tensor.requires_grad_()
         return tensor.reshape(size)
 
     def full(self, size, fill_value, dtype=torch.int):
@@ -260,6 +288,21 @@ class Iris:
     def wall_clock_rate(self, rank):
         return get_wall_clock_rate(rank)
 
+    def __throw_if_invalid_output_tensor(self, tensor: torch.Tensor, num_elements: int, dtype: torch.dtype):
+        if not self.__tensor_on_device(tensor):
+            raise RuntimeError(f"The output tensor is not on the same device as the Iris instance. The Iris instance is on device {self.device} but the output tensor is on device {tensor.device}")
+        if not self.__on_symmetric_heap(tensor):
+            raise RuntimeError(f"The output tensor is not on the symmetric heap. The Iris instance is on heap base {self.heap_bases[self.cur_rank]} but the output tensor is on heap base {tensor.data_ptr()}")
+        if tensor.numel() != num_elements:
+            raise RuntimeError(f"The output tensor has {tensor.numel()} elements, but {num_elements} are required")
+        if tensor.dtype != dtype:
+            raise RuntimeError(f"The output tensor has dtype {tensor.dtype}, but {dtype} is required")
+
+    def __tensor_on_device(self, tensor: torch.Tensor):
+        return tensor.device == self.device
+
+    def __on_symmetric_heap(self, tensor: torch.Tensor):
+        return tensor.data_ptr() >= self.heap_bases[self.cur_rank] and tensor.data_ptr() < self.heap_bases[self.cur_rank] + self.heap_size
 
 @triton.jit
 def translate(src_ptr, cur_rank, target_rank, heap_bases, debug=False):

--- a/tests/examples/test_load_bench.py
+++ b/tests/examples/test_load_bench.py
@@ -48,7 +48,13 @@ def test_load_bench(dtype, buffer_size, heap_size, block_size):
 
     bandwidth_matrix = np.zeros((num_ranks, num_ranks), dtype=np.float32)
     element_size_bytes = torch.tensor([], dtype=dtype).element_size()
-    source_buffer = shmem.arange(buffer_size // element_size_bytes, device="cuda", dtype=dtype)
+    max_elements = buffer_size // element_size_bytes
+
+    max_val = torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
+    num_elements = min(max_elements, max_val)
+
+    print(f"num_elements: {num_elements}")
+    source_buffer = shmem.arange(num_elements, device="cuda", dtype=dtype)
     result_buffer = shmem.zeros_like(source_buffer)
 
     for source_rank in range(num_ranks):

--- a/tests/examples/test_load_bench.py
+++ b/tests/examples/test_load_bench.py
@@ -48,9 +48,7 @@ def test_load_bench(dtype, buffer_size, heap_size, block_size):
 
     bandwidth_matrix = np.zeros((num_ranks, num_ranks), dtype=np.float32)
     element_size_bytes = torch.tensor([], dtype=dtype).element_size()
-    max_elements = buffer_size // element_size_bytes
-
-    source_buffer = shmem.ones(max_elements, dtype=dtype)
+    source_buffer = shmem.ones(buffer_size // element_size_bytes, dtype=dtype)
     result_buffer = shmem.zeros_like(source_buffer)
 
     for source_rank in range(num_ranks):

--- a/tests/examples/test_load_bench.py
+++ b/tests/examples/test_load_bench.py
@@ -23,7 +23,7 @@ spec.loader.exec_module(module)
 @pytest.mark.parametrize(
     "dtype",
     [
-        torch.int8,  # ISSUE!
+        torch.int8,
         torch.float16,
         torch.bfloat16,
         torch.float32,
@@ -38,8 +38,8 @@ spec.loader.exec_module(module)
 @pytest.mark.parametrize(
     "block_size",
     [
-        256,
         512,
+        1024,
     ],
 )
 def test_load_bench(dtype, buffer_size, heap_size, block_size):

--- a/tests/examples/test_load_bench.py
+++ b/tests/examples/test_load_bench.py
@@ -53,7 +53,6 @@ def test_load_bench(dtype, buffer_size, heap_size, block_size):
     max_val = torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
     num_elements = min(max_elements, max_val)
 
-    print(f"num_elements: {num_elements}")
     source_buffer = shmem.arange(num_elements, device="cuda", dtype=dtype)
     result_buffer = shmem.zeros_like(source_buffer)
 

--- a/tests/examples/test_load_bench.py
+++ b/tests/examples/test_load_bench.py
@@ -50,10 +50,7 @@ def test_load_bench(dtype, buffer_size, heap_size, block_size):
     element_size_bytes = torch.tensor([], dtype=dtype).element_size()
     max_elements = buffer_size // element_size_bytes
 
-    max_val = torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
-    num_elements = min(max_elements, max_val)
-
-    source_buffer = shmem.arange(num_elements, device="cuda", dtype=dtype)
+    source_buffer = shmem.ones(max_elements, dtype=dtype)
     result_buffer = shmem.zeros_like(source_buffer)
 
     for source_rank in range(num_ranks):


### PR DESCRIPTION
This PR:
* Closes #45: Use `ones` instead of `arange` since `arange` overflows for int8
* Uses larger block size to avoid too many blocks (causes invalid launch parameters error)
* Cast to 64 bit numbers output of the [tl.arange](https://triton-lang.org/main/python-api/generated/triton.language.arange.html) to handle large number of elements
* Fixes `arange` and `ones` API to match PyTorch


```console
Apptainer> pytest -s tests/
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.10.18, pytest-7.3.2, pluggy-1.5.0
rootdir: /work1/amd/muhaawad/git/amd/pdp/iris
plugins: rerunfailures-14.0, xdoctest-1.2.0, hypothesis-5.35.1, xdist-3.3.1, cpp-2.3.0, anyio-4.9.0, flakefinder-1.1.0, typeguard-4.3.0
collected 72 items                                                                                                                                                         

tests/examples/test_load_bench.py ........
tests/unittests/test_get.py ................
tests/unittests/test_load.py ................
tests/unittests/test_put.py ................
tests/unittests/test_store.py ................

=========================================================================== 72 passed in 15.68s ============================================================================
```