### PR TITLE
Add triton package to build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "numpy",
     "requests",
     "mpi4py",
-    "ruff"
+    "ruff",
+    "triton"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR fixes: https://github.com/ROCm/iris/issues/68