### PR TITLE
Revert "Improve code documentation and APIs"

### DIFF
--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -9,6 +9,7 @@ import torch
 from .iris import (
     Iris,
     iris,
+    translate,
     load,
     store,
     get,
@@ -48,6 +49,7 @@ torch.cuda.memory.change_current_allocator(finegrained_allocator)
 __all__ = [
     "Iris",
     "iris",
+    "translate",
     "load",
     "store",
     "get",
@@ -58,5 +60,5 @@ __all__ = [
     "atomic_xchg",
     "do_bench",
     "memset_tensor",
-    "hip",
+    "hip"
 ]

--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -60,5 +60,5 @@ __all__ = [
     "atomic_xchg",
     "do_bench",
     "memset_tensor",
-    "hip"
+    "hip",
 ]


### PR DESCRIPTION
Reverts ROCm/iris#49

Mainly because I think we have to stick to using `sem` and `val`.