### PR TITLE
Use consistent argument naming with Triton

### DIFF
--- a/iris/iris.py
+++ b/iris/iris.py
@@ -442,7 +442,7 @@ def put(from_ptr, to_ptr, from_rank, to_rank, heap_bases, mask=None):
 
 
 @triton.jit
-def atomic_add(pointer, value, from_rank, to_rank, heap_bases, mask=None, semantics=None, scope=None):
+def atomic_add(pointer, val, from_rank, to_rank, heap_bases, mask=None, sem=None, scope=None):
     """
     Performs an atomic add at the specified rank's memory location.
 
@@ -453,23 +453,23 @@ def atomic_add(pointer, value, from_rank, to_rank, heap_bases, mask=None, semant
 
     Args:
         pointer (triton.PointerType, or block of dtype=triton.PointerType): The memory locations in the from_rank's address space that will be translated to the to_rank's address space. Must be the current rank where the pointer is local.
-        value (Block of dtype=pointer.dtype.element_ty): The values with which to perform the atomic operation.
+        val (Block of dtype=pointer.dtype.element_ty): The values with which to perform the atomic operation.
         from_rank (int): The rank ID from which the pointer originates. Must be the current rank where the pointer is local.
         to_rank (int): The rank ID to which the atomic operation will be performed.
         heap_bases (triton.PointerType): Array containing the heap base addresses for all ranks.
         mask (Block of triton.int1, optional): If mask[idx] is false, do not perform the atomic operation at address pointer[idx]. Defaults to None.
-        semantics (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". If not provided, the function defaults to using "acq_rel" semantics.
+        sem (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". If not provided, the function defaults to using "acq_rel" semantics.
         scope (str, optional): Defines the scope of threads that observe the synchronizing effect of the atomic operation. Acceptable values are "gpu" (default), "cta" (cooperative thread array, thread block), or "sys" (stands for "SYSTEM"). The default value is "gpu".
 
     Returns:
         Block: The data stored at pointer before the atomic operation.
     """
     translated_ptr = __translate(pointer, from_rank, to_rank, heap_bases)
-    return tl.atomic_add(translated_ptr, value, mask=mask, sem=semantics, scope=scope)
+    return tl.atomic_add(translated_ptr, val, mask=mask, sem=sem, scope=scope)
 
 
 @triton.jit
-def atomic_sub(pointer, value, from_rank, to_rank, heap_bases, mask=None, semantics=None, scope=None):
+def atomic_sub(pointer, val, from_rank, to_rank, heap_bases, mask=None, sem=None, scope=None):
     """
     Atomically subtracts data from the specified rank's memory location.
 
@@ -480,23 +480,23 @@ def atomic_sub(pointer, value, from_rank, to_rank, heap_bases, mask=None, semant
 
     Args:
         pointer (triton.PointerType, or block of dtype=triton.PointerType): Pointer in the from_rank's address space that will be translated to the to_rank's address space. Must be the current rank where the pointer is local.
-        value (Block): The tensor of elements to be subtracted atomically.
+        val (Block): The tensor of elements to be subtracted atomically.
         from_rank (int): The rank ID from which the pointer originates. Must be the current rank where the pointer is local.
         to_rank (int): The rank ID to which the atomic operation will be performed.
         heap_bases (triton.PointerType): Array containing the heap base addresses for all ranks.
         mask (Block of triton.int1, optional): If mask[idx] is false, do not perform the atomic operation at address pointer[idx]. Defaults to None.
-        semantics (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". Defaults to "acq_rel".
+        sem (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". Defaults to "acq_rel".
         scope (str, optional): Defines the scope of threads that observe the synchronizing effect of the atomic operation. Acceptable values are "gpu" (default), "cta" (cooperative thread array, thread block), or "sys" (stands for "SYSTEM"). Defaults to "gpu".
 
     Returns:
         Block: The value at the memory location before the atomic subtraction.
     """
     translated_ptr = __translate(pointer, from_rank, to_rank, heap_bases)
-    return tl.atomic_sub(translated_ptr, value, mask=mask, sem=semantics, scope=scope)
+    return tl.atomic_sub(translated_ptr, val, mask=mask, sem=sem, scope=scope)
 
 
 @triton.jit
-def atomic_cas(pointer, cmp, value, from_rank, to_rank, heap_bases, semantics=None, scope=None):
+def atomic_cas(pointer, cmp, val, from_rank, to_rank, heap_bases, sem=None, scope=None):
     """
     Atomically compares and exchanges the specified rank's memory location.
 
@@ -508,22 +508,22 @@ def atomic_cas(pointer, cmp, value, from_rank, to_rank, heap_bases, semantics=No
     Args:
         pointer (triton.PointerType, or block of dtype=triton.PointerType): Pointer in the from_rank's address space that will be translated to the to_rank's address space. Must be the current rank where the pointer is local.
         cmp (Block): The expected value to be compared with the current value at the memory location.
-        value (Block): The new value to be written if the compare succeeds.
+        val (Block): The new value to be written if the compare succeeds.
         from_rank (int): The rank ID from which the pointer originates. Must be the current rank where the pointer is local.
         to_rank (int): The rank ID to which the atomic operation will be performed.
         heap_bases (triton.PointerType): Array containing the heap base addresses for all ranks.
-        semantics (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". Defaults to "acq_rel".
+        sem (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". Defaults to "acq_rel".
         scope (str, optional): Defines the scope of threads that observe the synchronizing effect of the atomic operation. Acceptable values are "gpu" (default), "cta" (cooperative thread array, thread block), or "sys" (stands for "SYSTEM"). Defaults to "gpu".
 
     Returns:
         Block: The value contained at the memory location before the atomic operation attempt.
     """
     translated_ptr = __translate(pointer, from_rank, to_rank, heap_bases)
-    return tl.atomic_cas(translated_ptr, cmp, value, sem=semantics, scope=scope)
+    return tl.atomic_cas(translated_ptr, cmp, val, sem=sem, scope=scope)
 
 
 @triton.jit
-def atomic_xchg(pointer, value, from_rank, to_rank, heap_bases, mask=None, semantics=None, scope=None):
+def atomic_xchg(pointer, val, from_rank, to_rank, heap_bases, mask=None, sem=None, scope=None):
     """
     Performs an atomic exchange at the specified rank's memory location.
 
@@ -534,19 +534,19 @@ def atomic_xchg(pointer, value, from_rank, to_rank, heap_bases, mask=None, seman
 
     Args:
         pointer (triton.PointerType, or block of dtype=triton.PointerType): The memory locations in the from_rank's address space that will be translated to the to_rank's address space. Must be the current rank where the pointer is local.
-        value (Block of dtype=pointer.dtype.element_ty): The values with which to perform the atomic operation.
+        val (Block of dtype=pointer.dtype.element_ty): The values with which to perform the atomic operation.
         from_rank (int): The rank ID from which the pointer originates. Must be the current rank where the pointer is local.
         to_rank (int): The rank ID to which the atomic operation will be performed.
         heap_bases (triton.PointerType): Array containing the heap base addresses for all ranks.
         mask (Block of triton.int1, optional): If mask[idx] is false, do not perform the atomic operation at address pointer[idx]. Defaults to None.
-        semantics (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". If not provided, the function defaults to using "acq_rel" semantics.
+        sem (str, optional): Specifies the memory semantics for the operation. Acceptable values are "acquire", "release", "acq_rel" (stands for "ACQUIRE_RELEASE"), and "relaxed". If not provided, the function defaults to using "acq_rel" semantics.
         scope (str, optional): Defines the scope of threads that observe the synchronizing effect of the atomic operation. Acceptable values are "gpu" (default), "cta" (cooperative thread array, thread block), or "sys" (stands for "SYSTEM"). The default value is "gpu".
 
     Returns:
         Block: The data stored at pointer before the atomic operation.
     """
     translated_ptr = __translate(pointer, from_rank, to_rank, heap_bases)
-    return tl.atomic_xchg(translated_ptr, value, mask=mask, sem=semantics, scope=scope)
+    return tl.atomic_xchg(translated_ptr, val, mask=mask, sem=sem, scope=scope)
 
 
 def iris(heap_size=1 << 30):


### PR DESCRIPTION
This PR reverts the `semantic` and `value` argument naming to `semantic` and `val`. Replaces #81.

<details><summary>Tests output</summary>
<p>

```terminal
Apptainer> pytest tests/
========================================================== test session starts ==========================================================
platform linux -- Python 3.10.18, pytest-7.3.2, pluggy-1.5.0
rootdir: /work1/amd/muhaawad/git/amd/pdp/iris
plugins: rerunfailures-14.0, xdoctest-1.2.0, hypothesis-5.35.1, xdist-3.3.1, cpp-2.3.0, anyio-4.9.0, flakefinder-1.1.0, typeguard-4.3.0
collected 306 items                                                                                                                     

tests/examples/test_load_bench.py ........                                                                                        [  2%]
tests/unittests/test_atomic_add.py .............................................................................................. [ 33%]
......................................................................................                                            [ 61%]
tests/unittests/test_atomic_cas.py ...........................                                                                    [ 70%]
tests/unittests/test_atomic_xchg.py ...........................                                                                   [ 79%]
tests/unittests/test_get.py ................                                                                                      [ 84%]
tests/unittests/test_load.py ................                                                                                     [ 89%]
tests/unittests/test_put.py ................                                                                                      [ 94%]
tests/unittests/test_store.py ................                                                                                    [100%]

========================================================= 306 passed in 45.98s ==========================================================
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_remainder_iters_streamk= 208
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_programs_streamk=304
total_blocking_tiles=0
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
M,N,K=8192,576,36864 ; BLK_M,N,K=256,64,64
total_blocks_M=32 x total_blocks_N=9 = total_tiles=288
total_tiles_streamk=288 + total_blocking_tiles=0 = total_tiles=288
total_programs_streamk=304
total_blocking_tiles=0
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
total_full_tiles_streamk=545
iters_per_tile=576
total_iters_streamk=165888
total_remainder_iters_streamk= 208
254 registers used, 0 spills
256 registers used, 15 spills
256 registers used, 15 spills
254 registers used, 0 spills
256 registers used, 15 spills
256 registers used, 15 spills
256 registers used, 13 spills
256 registers used, 13 spills
[Iris] [4/8] Validating...
[Iris] [1/8] Validating...
[Iris] [2/8] Validating...
[Iris] [6/8] Validating...
[Iris] [5/8] Validating...
[Iris] [7/8] Validating...
[Iris] [3/8] Validating...
[Iris] [0/8] Validating...
[Iris] [3/8] Final C validation passed.
[Iris] [2/8] Final C validation passed.
[Iris] [6/8] Final C validation passed.
[Iris] [0/8] Final C validation passed.
[Iris] [5/8] Final C validation passed.
[Iris] [7/8] Final C validation passed.
[Iris] [1/8] Final C validation passed.
[Iris] [4/8] Final C validation passed.
[Iris] [5/8] Validating local C...
[Iris] [5/8] Validation completed
[Iris] [5/8] Benchmarking...
[Iris] [1/8] Validating local C...
[Iris] [1/8] Validation completed
[Iris] [1/8] Benchmarking...
[Iris] [4/8] Validating local C...
[Iris] [4/8] Validation completed
[Iris] [4/8] Benchmarking...
[Iris] [7/8] Validating local C...
[Iris] [7/8] Validation completed
[Iris] [7/8] Benchmarking...
[Iris] [3/8] Validating local C...
[Iris] [3/8] Validation completed
[Iris] [3/8] Benchmarking...
[Iris] [0/8] Validating local C...
[Iris] [0/8] Validation completed
[Iris] [0/8] Benchmarking...
[Iris] [6/8] Validating local C...
[Iris] [6/8] Validation completed
[Iris] [6/8] Benchmarking...
[Iris] [2/8] Validating local C...
[Iris] [2/8] Validation completed
[Iris] [2/8] Benchmarking...
[Iris] [7/8] tile matmul + all_scatter (grid=288): 1.689 ms  1648.176 tflops
[Iris] [5/8] tile matmul + all_scatter (grid=288): 1.677 ms  1659.731 tflops
[Iris] [6/8] tile matmul + all_scatter (grid=288): 1.687 ms  1649.591 tflops
[Iris] [3/8] tile matmul + all_scatter (grid=288): 1.687 ms  1649.864 tflops
[Iris] [1/8] tile matmul + all_scatter (grid=288): 1.680 ms  1656.219 tflops
[Iris] [2/8] tile matmul + all_scatter (grid=288): 1.690 ms  1647.299 tflops
[Iris] [0/8] tile matmul + all_scatter (grid=288): 1.691 ms  1646.209 tflops
[Iris] [4/8] tile matmul + all_scatter (grid=288): 1.685 ms  1651.757 tflops
{
    "world_size": 8,
    "m": 8192,
    "n": 576,
    "k": 36864,
    "debug": false,
    "validate": true,
    "trace_tiles": false,
    "benchmark": true,
    "datatype": "fp16",
    "algorithm": "all_reduce",
    "output_file": "log.json",
    "BLK_M": 256,
    "BLK_N": 64,
    "BLK_K": 64,
    "gsize_m": 4,
    "two_tiles": "True",
    "num_stages": 2,
    "num_warps": 8,
    "waves_per_eu": 0,
    "mfmaInstrSize": 16,
    "kpack": 1,
    "heap_size": 8589934592,
    "gemm_sms": 304,
    "M": 8192,
    "N": 4608,
    "K": 36864,
    "gemm_registers": 254,
    "gemm_spills": 0,
    "success": true,
    "triton_tflops": 1646.2088985443709,
    "triton_ms": 1.6906352591514588,
    "gemm_ms": 1.5033657200752744,
    "gemm_experiments": 126
}
```

</p>
</details> 