### PR TITLE
Bump triton

### DIFF
--- a/apptainer/iris.def
+++ b/apptainer/iris.def
@@ -13,7 +13,7 @@ From: rocm/pytorch:rocm6.3.1_ubuntu22.04_py3.10_pytorch
     conda install -y -n py_3.10 -c conda-forge mpi4py openmpi jupyter ninja cmake wheel
     git clone https://github.com/triton-lang/triton.git \$TRITON_PATH
     cd \$TRITON_PATH
-    git checkout eb73b0373a7fb4cd2e563f68e3488a96525562eb
+    git checkout dd5823453bcc7973eabadb65f9d827c43281c434
     pip install -e .
     wget https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.3.1/rocprofiler-systems-install.py
     python3 ./rocprofiler-systems-install.py --prefix /opt/rocprofiler-systems --rocm 6.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN sudo pip3 install mpi4py
 # Clone and install Triton
 WORKDIR $TRITON_PATH
 RUN git clone https://github.com/triton-lang/triton.git $TRITON_PATH
-RUN git checkout eb73b0373a7fb4cd2e563f68e3488a96525562eb
+RUN git checkout dd5823453bcc7973eabadb65f9d827c43281c434
 RUN pip3 install -e .
 ENV PYTHONPATH=$TRITON_PATH
 

--- a/tests/unittests/test_atomic_and.py
+++ b/tests/unittests/test_atomic_and.py
@@ -70,9 +70,9 @@ def test_atomic_and_api(dtype, sem, scope, BLOCK_SIZE):
     heap_bases = shmem.get_heap_bases()
     cur_rank = shmem.get_rank()
 
-    bit_width      = 32 if dtype == torch.int32 else 64
+    bit_width = 32 if dtype == torch.int32 else 64
     effective_bits = min(num_ranks, bit_width)
-    initial_mask   = (1 << effective_bits) - 1
+    initial_mask = (1 << effective_bits) - 1
 
     results = shmem.full((BLOCK_SIZE,), initial_mask, dtype=dtype)
 

--- a/tests/unittests/test_atomic_min.py
+++ b/tests/unittests/test_atomic_min.py
@@ -69,14 +69,14 @@ def test_atomic_min_api(dtype, sem, scope, BLOCK_SIZE):
     cur_rank = shmem.get_rank()
 
     max_val = torch.iinfo(dtype).max
-    results  = shmem.full((BLOCK_SIZE,), max_val, dtype=dtype)
+    results = shmem.full((BLOCK_SIZE,), max_val, dtype=dtype)
 
     grid = lambda meta: (1,)
     atomic_min_kernel[grid](results, sem, scope, cur_rank, num_ranks, BLOCK_SIZE, heap_bases)
     shmem.barrier()
     # All ranks participate in performing the max operation
     # Each rank performs the atomic operation: max(rank_id + 1)
-    # The result equals the ID of the first rank + 1 
+    # The result equals the ID of the first rank + 1
     expected = torch.full((BLOCK_SIZE,), 1, dtype=dtype, device="cuda")
 
     try:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Bump Triton to a recent SHA which is know for good performance.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Updated docker/apptainer files with new SHA.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
All tests passed.
```console
root@snapshots-gpu-mi300x8-1536gb-devcloud-atl1:~/iris# pytest tests/
===================================================================== test session starts =====================================================================
platform linux -- Python 3.10.16, pytest-7.3.2, pluggy-1.5.0
rootdir: /root/iris
plugins: hypothesis-5.35.1, cpp-2.3.0, flakefinder-1.1.0, rerunfailures-14.0, xdist-3.3.1, xdoctest-1.1.0, anyio-4.10.0, typeguard-4.3.0
collected 666 items                                                                                                                                           

tests/examples/test_load_bench.py ........                                                                                                              [  1%]
tests/unittests/test_atomic_add.py .................................................................................................................... [ 18%]
................................................................                                                                                        [ 28%]
tests/unittests/test_atomic_and.py ........................................................................                                             [ 39%]
tests/unittests/test_atomic_cas.py ...........................                                                                                          [ 43%]
tests/unittests/test_atomic_max.py ........................................................................                                             [ 53%]
tests/unittests/test_atomic_min.py ........................................................................                                             [ 64%]
tests/unittests/test_atomic_or.py ........................................................................                                              [ 75%]
tests/unittests/test_atomic_xchg.py ...........................                                                                                         [ 79%]
tests/unittests/test_atomic_xor.py ........................................................................                                             [ 90%]
tests/unittests/test_get.py ................                                                                                                            [ 92%]
tests/unittests/test_load.py ................                                                                                                           [ 95%]
tests/unittests/test_put.py ................                                                                                                            [ 97%]
tests/unittests/test_store.py ................                                                                                                          [100%]

==================================================================== 666 passed in 31.58s =====================================================================

```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
