### PR TITLE
Fix broken `get`

### DIFF
--- a/iris/iris.py
+++ b/iris/iris.py
@@ -407,7 +407,7 @@ def get(from_ptr, to_ptr, from_rank, to_rank, heap_bases, mask=None):
     Returns:
         None
     """
-    translated_from_ptr = __translate(from_ptr, to_rank, from_rank, heap_bases)
+    translated_from_ptr = __translate(from_ptr, from_rank, to_rank, heap_bases)
 
     data = tl.load(translated_from_ptr, mask=mask)
 


### PR DESCRIPTION
## Motivation

Similar to https://github.com/ROCm/iris/issues/107

## Technical Details

Got broken in #49

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

```
root@smci355-ccs-aus-n02-09:/home/muhaawad/git/amd/pdp/iris# mpirun -np 8 python -m pytest tests/unittests/test_get.py 
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... /opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... ========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... /opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... ========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... /opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... /opt/conda/envs/py_3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.10.17, pytest-8.3.5, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/muhaawad/git/amd/pdp/iris
configfile: pyproject.toml
plugins: cpp-2.3.0, rerunfailures-14.0, xdoctest-1.1.0, flakefinder-1.1.0, xdist-3.3.1, hypothesis-5.35.1, subtests-0.13.1, typeguard-4.4.3, mock-3.14.1, csv-3.0.0, random-order-1.1.1, cov-6.1.1, anyio-4.9.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 16 items                                                                                                                                                                                                                       
collected 16 items                                                                                                                                                                                                                       
collected 16 items                                                                                                                                                                                                                       

collected 16 items                                                                                                                                                                                                                       

tests/unittests/test_get.py 
tests/unittests/test_get.py 
collected 16 items                                                                                                                                                                                                                       
collected 16 items                                                                                                                                                                                                                       
collected 16 items                                                                                                                                                                                                                       
collected 16 items                                                                                                                                                                                                                       

tests/unittests/test_get.py 
tests/unittests/test_get.py 
tests/unittests/test_get.py 
tests/unittests/test_get.py ..............................................................................................................................                                                                                                                                                                                       [100%]                                                                                                                                                                                       [100%]                                                                                                                                                                                       [100%].                                                                                                                                                                                       [100%]                                                                                                                                                                                       [100%]                                                                                                                                                                                       [100%]                                                                                                                                                                                       [100%]
.
=========================================================================================================== 16 passed in 4.35s ===========================================================================================================



=========================================================================================================== 16 passed in 4.33s ===========================================================================================================


=========================================================================================================== 16 passed in 4.34s ===========================================================================================================
                                                                                                                                                                                       [100%]

=========================================================================================================== 16 passed in 4.37s ===========================================================================================================



=========================================================================================================== 16 passed in 4.33s ===========================================================================================================


=========================================================================================================== 16 passed in 4.34s ===========================================================================================================
=========================================================================================================== 16 passed in 4.36s ===========================================================================================================


=========================================================================================================== 16 passed in 4.35s ===========================================================================================================

```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
