### PR TITLE
Added ROCm 7.0 support ( fix #170)

### DIFF
--- a/.github/workflows/iris-tests-apptainer.yml
+++ b/.github/workflows/iris-tests-apptainer.yml
@@ -15,6 +15,9 @@ jobs:
   build-apptainer-image:
     runs-on: [self-hosted, mi3008x]
     timeout-minutes: 90
+    strategy:
+      matrix:
+        rocm_version: ["6.3.1", "7.0"]
 
     steps:
       - name: Checkout repository
@@ -32,20 +35,21 @@ jobs:
           mkdir -p ~/apptainer
 
           # Build Apptainer image from definition file (only if it doesn't exist)
-          if [ ! -f ~/apptainer/iris-dev.sif ]; then
-            echo "Building new Apptainer image..."
-            apptainer build ~/apptainer/iris-dev.sif apptainer/iris.def
+          if [ ! -f ~/apptainer/iris-dev-rocm${{ matrix.rocm_version }}.sif ]; then
+            echo "Building new Apptainer image for ROCm ${{ matrix.rocm_version }}..."
+            apptainer build ~/apptainer/iris-dev-rocm${{ matrix.rocm_version }}.sif apptainer/iris-rocm${{ matrix.rocm_version }}.def
           else
-            echo "Using existing Apptainer image"
+            echo "Using existing Apptainer image for ROCm ${{ matrix.rocm_version }}"
           fi
   run-tests:
-    name: ${{ matrix.ranks }}-rank Iris Test
+    name: ${{ matrix.ranks }}-rank Iris Test (ROCm ${{ matrix.rocm_version }})
     needs: build-apptainer-image
     runs-on: [self-hosted, mi3008x]
     timeout-minutes: 20
     strategy:
       matrix:
         ranks: [1, 2, 4, 8]
+        rocm_version: ["6.3.1", "7.0"]
       max-parallel: 1
 
     steps:
@@ -54,7 +58,7 @@ jobs:
 
       - name: Run Iris Tests with ${{ matrix.ranks }} ranks
         run: |
-          apptainer exec ~/apptainer/iris-dev.sif bash -c "
+          apptainer exec ~/apptainer/iris-dev-rocm${{ matrix.rocm_version }}.sif bash -c "
             set -e  # Exit on any error
 
             # Install iris first

--- a/apptainer/iris-rocm6.3.1.def
+++ b/apptainer/iris-rocm6.3.1.def
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+Bootstrap: docker
+From: rocm/pytorch:rocm6.3.1_ubuntu22.04_py3.10_pytorch
+
+%post
+    /bin/bash -c "
+    apt-get update && apt-get install -y git
+    export TRITON_PATH=/workspace/triton
+    conda env list
+    source /opt/conda/bin/activate py_3.10
+    conda install -y -n py_3.10 -c conda-forge jupyter ninja cmake wheel
+    git clone https://github.com/triton-lang/triton.git \$TRITON_PATH
+    cd \$TRITON_PATH
+    git checkout dd5823453bcc7973eabadb65f9d827c43281c434
+    pip install -e .
+    wget https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.3.1/rocprofiler-systems-install.py
+    python3 ./rocprofiler-systems-install.py --prefix /opt/rocprofiler-systems --rocm 6.3
+    "
+
+%environment
+    # Define environment variables
+    export TRITON_PATH=/workspace/triton
+    export PYTHONPATH=$TRITON_PATH/python/
+    export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
+    export ROCM_PATH=/opt/rocm
+    export PATH=/opt/conda/envs/py_3.10/bin:/opt/rocm/bin:$PATH
+    export OMPI_MCA_mtl="^ofi"
+    export OMPI_MCA_pml="ob1"
+
+%runscript
+    echo "Welcome to the ROCm-aware Apptainer image!"
+    source /opt/conda/bin/activate py_3.10
+    exec "$@"

--- a/apptainer/iris-rocm7.0.def
+++ b/apptainer/iris-rocm7.0.def
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+Bootstrap: docker
+From: rocm/pytorch:rocm7.0_ubuntu22.04_py3.10_pytorch_release_2.8.0
+
+%post
+    /bin/bash -c "
+    apt-get update && apt-get install -y git
+    export TRITON_PATH=/workspace/triton
+    conda env list
+    source /opt/conda/bin/activate py_3.10
+    conda install -y -n py_3.10 -c conda-forge jupyter ninja cmake wheel
+    git clone https://github.com/triton-lang/triton.git \$TRITON_PATH
+    cd \$TRITON_PATH
+    git checkout dd5823453bcc7973eabadb65f9d827c43281c434
+    pip install -e .
+    wget https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-7.0.0/rocprofiler-systems-install.py
+    python3 ./rocprofiler-systems-install.py --prefix /opt/rocprofiler-systems --rocm 7.0
+    "
+
+%environment
+    # Define environment variables
+    export TRITON_PATH=/workspace/triton
+    export PYTHONPATH=$TRITON_PATH/python/
+    export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
+    export ROCM_PATH=/opt/rocm
+    export PATH=/opt/conda/envs/py_3.10/bin:/opt/rocm/bin:$PATH
+    export OMPI_MCA_mtl="^ofi"
+    export OMPI_MCA_pml="ob1"
+
+%runscript
+    echo "Welcome to the ROCm-aware Apptainer image!"
+    source /opt/conda/bin/activate py_3.10
+    exec "$@"


### PR DESCRIPTION
## Motivation
Extend CI matrix to test against ROCm 7.0. Fix #170 

## Technical Details
  - `.github/workflows/iris-tests-apptainer.yml`: Extended CI matrix to test both ROCm 6.3.1 and 7.0
  - `apptainer/iris-rocm6.3.1.def`: Apptainer definition for ROCm 6.3.1
  - `apptainer/iris-rocm7.0.def`: Apptainer definition for ROCm 7.0

## Test Plan
Could not perform local testing since all AMD cloud droplets are currently out of stock.  
Submitting as a **Draft PR** to validate changes via CI.

## Test Result
N/A (pending)

## Submission Checklist
- [x] Reviewed [contributing guidelines](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests).
