### PR TITLE
Implement pytest tests for 06_message_passing examples

### DIFF
--- a/examples/06_message_passing/message_passing_load_store.py
+++ b/examples/06_message_passing/message_passing_load_store.py
@@ -48,7 +48,7 @@ def producer_kernel(
     )
 
     # Set flag to signal completion
-    tl.store(flag + pid, 1)
+    iris.atomic_cas(flag + pid, 0, 1, producer_rank, consumer_rank, heap_bases_ptr, sem="release", scope="sys")
 
 
 @triton.jit
@@ -67,9 +67,11 @@ def consumer_kernel(
     mask = offsets < buffer_size
 
     # Spin-wait until writer sets flag[pid] = 1
-    done = tl.load(flag + pid)
+    done = 0
     while done == 0:
-        done = tl.load(flag + pid)
+        done = iris.atomic_cas(
+            flag + pid, 1, 0, consumer_rank, consumer_rank, heap_bases_ptr, sem="acquire", scope="sys"
+        )
 
     # Read from the target buffer (written by producer)
     values = iris.load(buffer + offsets, consumer_rank, consumer_rank, heap_bases_ptr, mask=mask)
@@ -145,7 +147,11 @@ def _worker(local_rank: int, world_size: int, init_url: str, args: dict):
 
     # Allocate source and destination buffers on the symmetric heap
     source_buffer = shmem.zeros(args["buffer_size"], device="cuda", dtype=dtype)
-    destination_buffer = shmem.randn(args["buffer_size"], device="cuda", dtype=dtype)
+    if dtype.is_floating_point:
+        destination_buffer = shmem.randn(args["buffer_size"], device="cuda", dtype=dtype)
+    else:
+        ii = torch.iinfo(dtype)
+        destination_buffer = shmem.randint(ii.min, ii.max, (args["buffer_size"],), device="cuda", dtype=dtype)
 
     if world_size != 2:
         raise ValueError("This example requires exactly two processes.")

--- a/tests/examples/test_message_passing.py
+++ b/tests/examples/test_message_passing.py
@@ -47,7 +47,11 @@ def run_message_passing_kernels(module, args):
 
     # Allocate source and destination buffers on the symmetric heap - match original examples
     source_buffer = shmem.zeros(args["buffer_size"], device="cuda", dtype=dtype)
-    destination_buffer = shmem.randn(args["buffer_size"], device="cuda", dtype=dtype)
+    if dtype.is_floating_point:
+        destination_buffer = shmem.randn(args["buffer_size"], device="cuda", dtype=dtype)
+    else:
+        ii = torch.iinfo(dtype)
+        destination_buffer = shmem.randint(ii.min, ii.max, (args["buffer_size"],), device="cuda", dtype=dtype)
 
     producer_rank = 0
     consumer_rank = 1


### PR DESCRIPTION
## Motivation

This clears some issues that were causing copilot's fix to fail: https://github.com/ROCm/iris/pull/127.

## Technical Details
Fixed two issues with the new test:

* Message passing needs to use CAS in order for tests to pass reliably.
* `torch.randn` doesn't work for integers, so use `torch.randint` instead for integral types.

## Test Plan

The new test case is run like this:
```
python tests/run_tests_distributed.py --num_ranks 2 tests/examples/test_message_passing.py
```
The test has to be run multiple times to try to catch race conditions.

## Test Result

The test suite would fail before because `torch.randn` is unimplemented for int8. In roughly 1/4 runs, a test would fail due to a race condition when handing data off from producer to consumer. I ran the test cases 8 more times and there were no issues.

Fixes #60.