### PR TITLE
Update package metadata to PEP 621 format with backward compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,21 +8,25 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "iris"
 dynamic = ["version"]
-description = "Python- and Triton-based library that provide SHMEM-like RDMA support in Triton."
+description = "Triton-based framework for Remote Memory Access (RMA) operations with SHMEM-like APIs for multi-GPU programming."
 authors = [
     { name = "Muhammad Awad", email = "muhaawad@amd.com" },
     { name = "Muhammad Osama", email = "Muhammad.Osama@amd.com" },
     { name = "Brandon Potter", email = "Brandon.Potter@amd.com" }
 ]
-license = "MIT"
+license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
-
 dependencies = [
     "numpy",
     "requests",
     "ruff",
 ]
+
+[project.urls]
+Homepage = "https://rocm.github.io/iris/"
+Repository = "https://github.com/ROCm/iris"
+Documentation = "https://rocm.github.io/iris/"
 
 [project.optional-dependencies]
 dev = [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+from setuptools import setup
+
+# This setup.py provides backward compatibility for legacy metadata fields
+# that don't map directly from pyproject.toml's modern PEP 621 format.
+setup(
+    url="https://rocm.github.io/iris/",
+    author="Muhammad Awad, Muhammad Osama, Brandon Potter",
+    license="MIT",
+)

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,4 @@ from setuptools import setup
 setup(
     url="https://rocm.github.io/iris/",
     author="Muhammad Awad, Muhammad Osama, Brandon Potter",
-    license="MIT",
 )


### PR DESCRIPTION
## Motivation

Metadata are incomplete

## Technical Details

- Update pyproject.toml with modern PEP 621 metadata format
- Add project URLs for Homepage, Repository, and Documentation
- Update description to accurately describe Iris framework
- Add setup.py for backward compatibility with legacy pip show
- Ensure License field displays correctly as MIT

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
