### PR TITLE
Move simulation allocator guard into SymmetricHeap

### DIFF
--- a/iris/iris.py
+++ b/iris/iris.py
@@ -93,9 +93,6 @@ class Iris:
     """
 
     def __init__(self, heap_size=1 << 30, allocator_type="torch"):
-        if is_simulation_env():
-            allocator_type = "torch"
-
         # Initialize distributed environment
         comm, cur_rank, num_ranks = init_distributed()
         num_gpus = count_devices()

--- a/iris/symmetric_heap.py
+++ b/iris/symmetric_heap.py
@@ -15,6 +15,7 @@ import os
 from iris.allocators import TorchAllocator, VMemAllocator
 from iris.fd_passing import setup_fd_infrastructure
 from iris._distributed_helpers import distributed_allgather
+from iris.util import is_simulation_env
 
 
 class SymmetricHeap:
@@ -54,6 +55,9 @@ class SymmetricHeap:
         self.num_ranks = num_ranks
         allocator_type = os.environ.get("IRIS_ALLOCATOR", allocator_type).lower()
 
+        if is_simulation_env():
+            allocator_type = "torch"
+
         if allocator_type == "torch":
             self.allocator = TorchAllocator(heap_size, device_id, cur_rank, num_ranks)
         elif allocator_type == "vmem":
@@ -68,8 +72,6 @@ class SymmetricHeap:
         # Create from numpy array to avoid kernel issue (torch.zeros on small tensors triggers problematic kernel)
         heap_bases_array = np.zeros(self.num_ranks, dtype=np.int64)
         # Create on CPU first, then move to device to avoid FFM ioctl issue
-        from iris.util import is_simulation_env
-
         if is_simulation_env():
             self.heap_bases = torch.tensor(heap_bases_array, device="cpu", dtype=torch.int64)
             self.heap_bases = self.heap_bases.to(device)


### PR DESCRIPTION
## Summary
- Move the `is_simulation_env()` allocator override from `Iris.__init__()` into `SymmetricHeap.__init__()` so all backends (Triton and Gluon) are covered
- Clean up duplicate inline `is_simulation_env` import in `symmetric_heap.py`

## Test plan
- [ ] CI green
- [ ] Verify simulation mode still forces torch allocator via `Iris` (Triton backend)
- [ ] Verify simulation mode forces torch allocator via `IrisGluon` (Gluon backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)