### PR TITLE
Fix bench CLI validation, set_device guard, and docs

### DIFF
--- a/iris/bench/__init__.py
+++ b/iris/bench/__init__.py
@@ -51,7 +51,8 @@ The ``num_ranks`` Axis
 
 ``num_ranks`` is a special axis. It controls how many GPU processes are
 spawned.  The framework collects all unique ``num_ranks`` values across
-registered benchmarks, then does a separate ``mp.spawn()`` for each value.
+registered benchmarks, then launches a separate worker group via
+``torch.distributed.launcher.api.elastic_launch`` for each value.
 Other axes are iterated inside the worker processes.
 
 If no ``num_ranks`` axis is declared, the benchmark runs with 8 ranks.

--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -80,7 +80,13 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
             raise ValueError(
                 f"Invalid pow2 specification {raw!r} for axis {axis_name!r}; expected format 'pow2:start:stop'."
             )
-        return power_of_two(int(parts[1]), int(parts[2]))
+        try:
+            return power_of_two(int(parts[1]), int(parts[2]))
+        except ValueError:
+            raise ValueError(
+                f"Non-integer values in {raw!r} for axis {axis_name!r}; "
+                "expected format 'pow2:<int>:<int>'."
+            )
 
     if raw.startswith("lin:"):
         parts = raw.split(":")
@@ -88,18 +94,26 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
             raise ValueError(
                 f"Invalid linear specification {raw!r} for axis {axis_name!r}; expected format 'lin:start:stop:step'."
             )
-        return linear_range(int(parts[1]), int(parts[2]), int(parts[3]))
+        try:
+            return linear_range(int(parts[1]), int(parts[2]), int(parts[3]))
+        except ValueError:
+            raise ValueError(
+                f"Non-integer values in {raw!r} for axis {axis_name!r}; "
+                "expected format 'lin:<int>:<int>:<int>'."
+            )
 
     tokens = [t.strip() for t in raw.split(",")]
 
     # Check if they look like dtype names
     if axis_name == "dtype":
-        lower_tokens = [t.lower() for t in tokens]
-        unknown = [t for t in lower_tokens if t not in _DTYPE_MAP]
+        unknown = [t for t in tokens if t.lower() not in _DTYPE_MAP]
         if unknown:
             allowed = ", ".join(sorted(_DTYPE_MAP.keys()))
-            raise ValueError(f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. Allowed: {allowed}")
-        return [_DTYPE_MAP[t] for t in lower_tokens]
+            raise ValueError(
+                f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. "
+                f"Allowed: {allowed}"
+            )
+        return [_DTYPE_MAP[t.lower()] for t in tokens]
     if all(t.lower() in _DTYPE_MAP for t in tokens):
         return [_DTYPE_MAP[t.lower()] for t in tokens]
 
@@ -203,10 +217,12 @@ def _format_console(results: list[Result]) -> str:
             if r.skipped:
                 status = "(skipped)" + (f" {r.skip_reason}" if r.skip_reason else "")
                 if param_names:
-                    row = [cols[0][1](r)] + [status]
+                    row = [cols[0][1](r), status]
                     row += [""] * (len(cols) - 2)
-                else:
+                elif len(cols) > 1:
                     row = [status] + [""] * (len(cols) - 1)
+                else:
+                    row = [status]
                 row_strs.append(row)
             else:
                 row_strs.append([c[1](r) for c in cols])

--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -78,8 +78,7 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
         parts = raw.split(":")
         if len(parts) != 3:
             raise ValueError(
-                f"Invalid pow2 specification {raw!r} for axis {axis_name!r}; "
-                "expected format 'pow2:start:stop'."
+                f"Invalid pow2 specification {raw!r} for axis {axis_name!r}; expected format 'pow2:start:stop'."
             )
         return power_of_two(int(parts[1]), int(parts[2]))
 
@@ -87,8 +86,7 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
         parts = raw.split(":")
         if len(parts) != 4:
             raise ValueError(
-                f"Invalid linear specification {raw!r} for axis {axis_name!r}; "
-                "expected format 'lin:start:stop:step'."
+                f"Invalid linear specification {raw!r} for axis {axis_name!r}; expected format 'lin:start:stop:step'."
             )
         return linear_range(int(parts[1]), int(parts[2]), int(parts[3]))
 
@@ -100,10 +98,7 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
         unknown = [t for t in lower_tokens if t not in _DTYPE_MAP]
         if unknown:
             allowed = ", ".join(sorted(_DTYPE_MAP.keys()))
-            raise ValueError(
-                f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. "
-                f"Allowed: {allowed}"
-            )
+            raise ValueError(f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. Allowed: {allowed}")
         return [_DTYPE_MAP[t] for t in lower_tokens]
     if all(t.lower() in _DTYPE_MAP for t in tokens):
         return [_DTYPE_MAP[t.lower()] for t in tokens]

--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -84,8 +84,7 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
             return power_of_two(int(parts[1]), int(parts[2]))
         except ValueError:
             raise ValueError(
-                f"Non-integer values in {raw!r} for axis {axis_name!r}; "
-                "expected format 'pow2:<int>:<int>'."
+                f"Non-integer values in {raw!r} for axis {axis_name!r}; expected format 'pow2:<int>:<int>'."
             )
 
     if raw.startswith("lin:"):
@@ -98,8 +97,7 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
             return linear_range(int(parts[1]), int(parts[2]), int(parts[3]))
         except ValueError:
             raise ValueError(
-                f"Non-integer values in {raw!r} for axis {axis_name!r}; "
-                "expected format 'lin:<int>:<int>:<int>'."
+                f"Non-integer values in {raw!r} for axis {axis_name!r}; expected format 'lin:<int>:<int>:<int>'."
             )
 
     tokens = [t.strip() for t in raw.split(",")]
@@ -109,10 +107,7 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
         unknown = [t for t in tokens if t.lower() not in _DTYPE_MAP]
         if unknown:
             allowed = ", ".join(sorted(_DTYPE_MAP.keys()))
-            raise ValueError(
-                f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. "
-                f"Allowed: {allowed}"
-            )
+            raise ValueError(f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. Allowed: {allowed}")
         return [_DTYPE_MAP[t.lower()] for t in tokens]
     if all(t.lower() in _DTYPE_MAP for t in tokens):
         return [_DTYPE_MAP[t.lower()] for t in tokens]

--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -76,16 +76,36 @@ def _parse_axis_values(raw: str, axis_name: str) -> list[Any]:
 
     if raw.startswith("pow2:"):
         parts = raw.split(":")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Invalid pow2 specification {raw!r} for axis {axis_name!r}; "
+                "expected format 'pow2:start:stop'."
+            )
         return power_of_two(int(parts[1]), int(parts[2]))
 
     if raw.startswith("lin:"):
         parts = raw.split(":")
+        if len(parts) != 4:
+            raise ValueError(
+                f"Invalid linear specification {raw!r} for axis {axis_name!r}; "
+                "expected format 'lin:start:stop:step'."
+            )
         return linear_range(int(parts[1]), int(parts[2]), int(parts[3]))
 
     tokens = [t.strip() for t in raw.split(",")]
 
     # Check if they look like dtype names
-    if axis_name == "dtype" or all(t.lower() in _DTYPE_MAP for t in tokens):
+    if axis_name == "dtype":
+        lower_tokens = [t.lower() for t in tokens]
+        unknown = [t for t in lower_tokens if t not in _DTYPE_MAP]
+        if unknown:
+            allowed = ", ".join(sorted(_DTYPE_MAP.keys()))
+            raise ValueError(
+                f"Unknown dtype(s) for axis {axis_name!r}: {', '.join(unknown)}. "
+                f"Allowed: {allowed}"
+            )
+        return [_DTYPE_MAP[t] for t in lower_tokens]
+    if all(t.lower() in _DTYPE_MAP for t in tokens):
         return [_DTYPE_MAP[t.lower()] for t in tokens]
 
     # Try integers
@@ -186,8 +206,12 @@ def _format_console(results: list[Result]) -> str:
         row_strs: list[list[str]] = []
         for r in bench_results:
             if r.skipped:
-                row = [cols[0][1](r)] + ["(skipped)" + (f" {r.skip_reason}" if r.skip_reason else "")]
-                row += [""] * (len(cols) - 2)
+                status = "(skipped)" + (f" {r.skip_reason}" if r.skip_reason else "")
+                if param_names:
+                    row = [cols[0][1](r)] + [status]
+                    row += [""] * (len(cols) - 2)
+                else:
+                    row = [status] + [""] * (len(cols) - 1)
                 row_strs.append(row)
             else:
                 row_strs.append([c[1](r) for c in cols])
@@ -300,8 +324,9 @@ def _run_benchmarks_worker(
     local_rank = int(os.environ["LOCAL_RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
 
-    torch.cuda.set_device(local_rank)
     backend = "nccl" if torch.cuda.is_available() else "gloo"
+    if backend == "nccl":
+        torch.cuda.set_device(local_rank)
     dist.init_process_group(backend=backend)
 
     # Create iris context
@@ -343,7 +368,7 @@ def _run_benchmarks_worker(
             if axes:
                 axis_names = [a.name for a in axes]
                 axis_values = [a.values for a in axes]
-                combos = list(itertools.product(*axis_values))
+                combos = itertools.product(*axis_values)
             else:
                 axis_names = []
                 combos = [()]


### PR DESCRIPTION
## Summary

- Guard `torch.cuda.set_device()` behind `torch.cuda.is_available()` to avoid crash on CPU-only envs
- Validate `pow2:`/`lin:` axis format and dtype names with clear error messages instead of IndexError/KeyError
- Iterate parameter combos lazily instead of materializing full cartesian product
- Fix skipped-row console rendering for benchmarks with zero param columns
- Fix docstring referencing `mp.spawn()` when implementation uses `elastic_launch`

Addresses Copilot review comments from #484.

## Test plan

- [ ] Existing bench tests pass
- [ ] Manual: `--axis_dtype=float17` gives clear error
- [ ] Manual: `pow2:8` gives clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)