### PR TITLE
feat: ring-based all_gather with workspace preamble

### DIFF
--- a/iris/ccl/__init__.py
+++ b/iris/ccl/__init__.py
@@ -11,6 +11,7 @@ Collective operations are accessed through the Iris instance's ccl attribute:
 """
 
 from .config import Config
+from .all_gather import AllGatherWorkspace
 from .utils import ReduceOp
 
-__all__ = ["Config", "ReduceOp"]
+__all__ = ["Config", "AllGatherWorkspace", "ReduceOp"]

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -6,12 +6,32 @@ All-gather collective communication primitive for Iris.
 Gathers tensors from all ranks and concatenates them along the last dimension.
 """
 
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
 import torch
 import triton
 import triton.language as tl
 import iris
 from .config import Config
 from .utils import extract_group_info
+
+
+@dataclass
+class AllGatherWorkspace:
+    """
+    Holds reusable workspace allocations for ring-based all-gather.
+
+    Pre-allocate via ``all_gather_preamble`` and pass to ``all_gather``
+    to avoid per-call heap allocation overhead.
+    """
+
+    shape: Tuple[int, int] = ()
+    dtype: Optional[torch.dtype] = None
+    ring_buffer: Optional[torch.Tensor] = None
+    flags: Optional[torch.Tensor] = None
+    flags_per_tile: int = 0
+    prepared: bool = False
 
 # Conditional import for Gluon
 try:
@@ -594,6 +614,69 @@ def persistent_all_gather_ring(
             tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
 
 
+def all_gather_preamble(
+    output_tensor,
+    input_tensor,
+    ctx,
+    config=None,
+    workspace=None,
+):
+    """
+    Pre-allocate reusable workspace for ring-based all-gather.
+
+    Call once, then pass the returned workspace to ``all_gather`` on
+    every iteration to avoid per-call symmetric-heap allocation.
+
+    Args:
+        output_tensor: Output tensor of shape (world_size * M, N).
+        input_tensor: Input tensor of shape (M, N).
+        ctx: Iris context.
+        config: Config instance (default: None → default Config).
+        workspace: Existing workspace to reuse (default: None → create new).
+
+    Returns:
+        AllGatherWorkspace ready for the next ``all_gather`` call.
+    """
+    if config is None:
+        config = Config(block_size_m=32, block_size_n=64)
+
+    M, N = input_tensor.shape[:2]
+    dtype = input_tensor.dtype
+
+    if workspace is None:
+        workspace = AllGatherWorkspace()
+
+    workspace.shape = (M, N)
+    workspace.dtype = dtype
+    workspace.prepared = False
+
+    if config.all_gather_variant == "ring":
+        num_pid_m = triton.cdiv(M, config.block_size_m)
+        num_pid_n = triton.cdiv(N, config.block_size_n)
+        total_tiles = num_pid_m * num_pid_n
+        workspace.flags_per_tile = 1
+        total_flags = total_tiles * workspace.flags_per_tile
+
+        if (
+            workspace.ring_buffer is None
+            or workspace.ring_buffer.shape != (M, N)
+            or workspace.ring_buffer.dtype != dtype
+        ):
+            workspace.ring_buffer = ctx.zeros((M, N), dtype=dtype)
+        else:
+            workspace.ring_buffer.zero_()
+
+        if workspace.flags is None or workspace.flags.numel() != total_flags:
+            workspace.flags = ctx.zeros((total_flags,), dtype=torch.int32)
+        else:
+            workspace.flags.zero_()
+
+        ctx.barrier()
+
+    workspace.prepared = True
+    return workspace
+
+
 def all_gather(
     output_tensor,
     input_tensor,
@@ -601,6 +684,7 @@ def all_gather(
     group=None,
     async_op=False,
     config=None,
+    workspace=None,
 ):
     """
     Internal all-gather collective operation implementation.
@@ -729,15 +813,21 @@ def all_gather(
         heap_bases = ctx.get_heap_bases()
 
         if config.all_gather_variant == "ring":
-            # Ring variant: allocate ring buffer and flags for producer/consumer sync
-            ring_buffer = ctx.zeros((M, N), dtype=input_tensor.dtype)
-
-            num_pid_m = triton.cdiv(M, config.block_size_m)
-            num_pid_n = triton.cdiv(N, config.block_size_n)
-            total_tiles = num_pid_m * num_pid_n
-            flags_per_tile = 1
-            total_flags = total_tiles * flags_per_tile
-            flags = ctx.zeros((total_flags,), dtype=torch.int32)
+            # Ring variant: use workspace if provided, otherwise allocate
+            if workspace is not None and workspace.prepared:
+                ring_buffer = workspace.ring_buffer
+                flags = workspace.flags
+                flags_per_tile = workspace.flags_per_tile
+                workspace.prepared = False
+            else:
+                ring_buffer = ctx.zeros((M, N), dtype=input_tensor.dtype)
+                num_pid_m = triton.cdiv(M, config.block_size_m)
+                num_pid_n = triton.cdiv(N, config.block_size_n)
+                total_tiles = num_pid_m * num_pid_n
+                flags_per_tile = 1
+                total_flags = total_tiles * flags_per_tile
+                flags = ctx.zeros((total_flags,), dtype=torch.int32)
+                ctx.barrier()
 
             # Calculate next rank in the ring
             if group is None:
@@ -748,8 +838,6 @@ def all_gather(
                 group_ranks = dist.get_process_group_ranks(group)
                 next_rank_in_group = (rank_in_group + 1) % world_size
                 next_rank = group_ranks[next_rank_in_group]
-
-            ctx.barrier()
 
             persistent_all_gather_ring[(config.comm_sms,)](
                 input_tensor,

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -29,6 +29,7 @@ class AllGatherWorkspace:
     shape: Tuple[int, int] = ()
     dtype: Optional[torch.dtype] = None
     ring_buffer: Optional[torch.Tensor] = None
+    ring_buffer_1: Optional[torch.Tensor] = None  # Second buffer for double-buffering
     flags: Optional[torch.Tensor] = None
     flags_per_tile: int = 0
     prepared: bool = False
@@ -467,7 +468,8 @@ if GLUON_AVAILABLE:
 def persistent_all_gather_ring(
     input_ptr,
     output_ptr,
-    ring_buffer,
+    ring_buffer_0,
+    ring_buffer_1,
     flags,
     M,
     N,
@@ -499,15 +501,17 @@ def persistent_all_gather_ring(
     the shard received in step k-1 to rank (r+1). After world_size-1
     steps, every rank has all shards in its output buffer.
 
-    Synchronization: uses a global per-step barrier instead of per-tile
-    flags. All CUs write tiles for a step in parallel, then synchronize
-    once per step. This reduces remote atomic traffic from O(tiles * steps)
-    to O(steps).
+    Synchronization: uses a global per-step barrier with monotonic counters
+    instead of per-tile flags. All CUs write tiles for a step in parallel,
+    then synchronize once per step via a local done-counter + single remote
+    signal. This reduces remote atomic traffic from O(tiles * steps) to
+    O(steps).
 
-    Flags layout (3 int32 values on symmetric heap):
-      flags[0]: send_done counter — local CUs atomic_add after finishing tiles
-      flags[1]: recv_ready — set by predecessor after all its tiles are sent
-      flags[2]: next rank's recv_ready target (written via iris.atomic_xchg)
+    Flags layout (2 int32 values on symmetric heap):
+      flags[0]: send_done — local CUs atomic_add after finishing tiles
+      flags[1]: recv_ready — monotonic counter set by predecessor via
+                iris.atomic_xchg to step number (1, 2, 3, ...).
+                Each CU waits for recv_ready >= current step.
     """
     pid = tl.program_id(0)
 
@@ -518,18 +522,14 @@ def persistent_all_gather_ring(
 
     # Barrier flag pointers
     send_done_ptr = flags + 0  # CUs count here when done sending tiles
-    recv_ready_ptr = flags + 1  # Predecessor sets this when its data is ready
+    recv_ready_ptr = flags + 1  # Predecessor writes step number here
 
     for _step in range(0, world_size - 1):
-        # Which shard are we forwarding?
-        # Step 0: our own shard (group_rank). Step k: shard (group_rank - k).
-        # Add world_size before modulo to avoid negative values
-        # (Triton uses C truncated-division semantics, not Python floored).
-        source_rank_idx = (group_rank + world_size - _step) % world_size
-
         if _step > 0:
             # Wait for predecessor to deliver data into our ring_buffer
-            while tl.atomic_cas(recv_ready_ptr, 1, 1, sem="acquire", scope="sys") != 1:
+            # Predecessor sets recv_ready to _step when step _step's data is ready.
+            # Use atomic_cas as a load: compare with 0, swap with 0 — returns current value.
+            while tl.atomic_cas(recv_ready_ptr, 0, 0, sem="acquire", scope="sys") < _step:
                 pass
 
         # --- All CUs process tiles in parallel ---
@@ -566,8 +566,9 @@ def persistent_all_gather_ring(
                 out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
                 tl.store(output_ptr + out_offset, send_data, mask=mask, cache_modifier=".wt")
             else:
-                # Load from ring_buffer (data from predecessor)
-                send_data = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
+                # Load from ring_buffer (predecessor wrote to buf[_step % 2])
+                read_buf = ring_buffer_0 if _step % 2 == 0 else ring_buffer_1
+                send_data = tl.load(read_buf + tile_offset, mask=mask, other=0)
                 # Write to output at the received shard's slot
                 recv_rank_idx = (group_rank + world_size - _step) % world_size
                 rm_recv = rm + recv_rank_idx * M
@@ -575,8 +576,10 @@ def persistent_all_gather_ring(
                 tl.store(output_ptr + out_offset_recv, send_data, mask=mask, cache_modifier=".wt")
 
             # Forward tile to next rank's ring_buffer
+            # Write to buf[(_step + 1) % 2] so next rank can read while we use the other
+            write_buf = ring_buffer_0 if (_step + 1) % 2 == 0 else ring_buffer_1
             iris.store(
-                ring_buffer + tile_offset,
+                write_buf + tile_offset,
                 send_data,
                 iris_rank,
                 next_rank,
@@ -589,12 +592,10 @@ def persistent_all_gather_ring(
         tl.debug_barrier()
         done_count = tl.atomic_add(send_done_ptr, 1, sem="release", scope="gpu")
         if done_count == (_step + 1) * COMM_SMS - 1:
-            # Last CU: reset recv_ready for next step, signal next rank
-            if _step > 0:
-                tl.atomic_xchg(recv_ready_ptr, 0, sem="release", scope="sys")
+            # Last CU: signal next rank that step (_step+1) data is ready
             iris.atomic_xchg(
                 recv_ready_ptr,
-                1,
+                _step + 1,
                 iris_rank,
                 next_rank,
                 heap_bases,
@@ -603,7 +604,8 @@ def persistent_all_gather_ring(
             )
 
     # === Final receive: last shard from predecessor, no forwarding ===
-    while tl.atomic_cas(recv_ready_ptr, 1, 1, sem="acquire", scope="sys") != 1:
+    _last_step = world_size - 1
+    while tl.atomic_cas(recv_ready_ptr, 0, 0, sem="acquire", scope="sys") < _last_step:
         pass
 
     for tile_id in range(pid, total_tiles, COMM_SMS):
@@ -627,9 +629,11 @@ def persistent_all_gather_ring(
         mask = (rm[:, None] < M) & (rn[None, :] < N)
         tile_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
 
-        recv_data = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
+        # Final step reads from buf[(world_size - 1) % 2]
+        final_buf = ring_buffer_0 if (world_size - 1) % 2 == 0 else ring_buffer_1
+        recv_data = tl.load(final_buf + tile_offset, mask=mask, other=0)
 
-        # Final shard: goes to slot (group_rank - (world_size-1)) mod world_size
+        # Final shard: goes to slot (group_rank + 1) mod world_size
         recv_rank_idx = (group_rank + 1) % world_size
         rm_recv = rm + recv_rank_idx * M
         out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
@@ -675,17 +679,16 @@ def all_gather_preamble(
     if config.all_gather_variant == "ring":
         workspace.flags_per_tile = 1  # Unused, kept for API compat
 
-        if (
-            workspace.ring_buffer is None
-            or workspace.ring_buffer.shape != (M, N)
-            or workspace.ring_buffer.dtype != dtype
-        ):
-            workspace.ring_buffer = ctx.zeros((M, N), dtype=dtype)
-        else:
-            workspace.ring_buffer.zero_()
+        # Double-buffered ring buffers (alternate per step to avoid WAR hazard)
+        for attr in ("ring_buffer", "ring_buffer_1"):
+            buf = getattr(workspace, attr)
+            if buf is None or buf.shape != (M, N) or buf.dtype != dtype:
+                setattr(workspace, attr, ctx.zeros((M, N), dtype=dtype))
+            else:
+                buf.zero_()
 
         # Global barrier uses 2 flags:
-        # [0] = send_done counter, [1] = recv_ready signal
+        # [0] = send_done counter, [1] = recv_ready signal (monotonic)
         total_flags = 2
         if workspace.flags is None or workspace.flags.numel() != total_flags:
             workspace.flags = ctx.zeros((total_flags,), dtype=torch.int32)
@@ -837,12 +840,14 @@ def all_gather(
         if config.all_gather_variant == "ring":
             # Ring variant: use workspace if provided, otherwise allocate
             if workspace is not None and workspace.prepared:
-                ring_buffer = workspace.ring_buffer
+                ring_buffer_0 = workspace.ring_buffer
+                ring_buffer_1 = workspace.ring_buffer_1
                 flags = workspace.flags
                 flags_per_tile = workspace.flags_per_tile
                 workspace.prepared = False
             else:
-                ring_buffer = ctx.zeros((M, N), dtype=input_tensor.dtype)
+                ring_buffer_0 = ctx.zeros((M, N), dtype=input_tensor.dtype)
+                ring_buffer_1 = ctx.zeros((M, N), dtype=input_tensor.dtype)
                 flags_per_tile = 1
                 # Global barrier: 2 flags (send_done counter + recv_ready)
                 flags = ctx.zeros((2,), dtype=torch.int32)
@@ -864,7 +869,8 @@ def all_gather(
             persistent_all_gather_ring[(config.comm_sms,)](
                 input_tensor,
                 output_tensor,
-                ring_buffer,
+                ring_buffer_0,
+                ring_buffer_1,
                 flags,
                 M,
                 N,

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -597,7 +597,7 @@ def persistent_all_gather_ring(
 def all_gather(
     output_tensor,
     input_tensor,
-    shmem,
+    ctx,
     group=None,
     async_op=False,
     config=None,
@@ -605,9 +605,9 @@ def all_gather(
     """
     Internal all-gather collective operation implementation.
 
-    This function is called internally by shmem.ccl.all_gather().
+    This function is called internally by ctx.ccl.all_gather().
     Users should use the Iris instance method instead:
-        >>> shmem.ccl.all_gather(output_tensor, input_tensor)
+        >>> ctx.ccl.all_gather(output_tensor, input_tensor)
 
     Each rank sends its input tensor to all ranks, and all ranks receive
     and concatenate all input tensors along dimension 0 (rows), matching
@@ -616,7 +616,7 @@ def all_gather(
     Args:
         output_tensor: Output tensor of shape (world_size * M, N) - will contain concatenated inputs
         input_tensor: Input tensor of shape (M, N) - local rank's data to send
-        shmem: Iris shmem context
+        ctx: Iris context
         group: ProcessGroup or None. If None, uses all ranks in `iris` context.
                Default: None.
         async_op: If False, performs a barrier at the end. If True, returns immediately.
@@ -632,7 +632,7 @@ def all_gather(
     # Extract group information
     # rank_in_group: position within the ProcessGroup (0, 1, 2, ...) - passed as group_rank to kernel
     # rank_global: global rank in iris context - passed as iris_rank to kernel for RMA operations
-    rank_in_group, rank_global, world_size, rank_start, rank_stride = extract_group_info(group, shmem)
+    rank_in_group, rank_global, world_size, rank_start, rank_stride = extract_group_info(group, ctx)
 
     M, N = input_tensor.shape[:2]
     expected_output_shape = (world_size * M, N)
@@ -648,8 +648,8 @@ def all_gather(
 
     # Choose between Triton and Gluon implementation
     if config.use_gluon and GLUON_AVAILABLE:
-        # Check if shmem is Iris Gluon (has get_device_context method)
-        if not hasattr(shmem, "get_device_context"):
+        # Check if ctx is Iris Gluon (has get_device_context method)
+        if not hasattr(ctx, "get_device_context"):
             raise ValueError("use_gluon=True requires Iris Gluon context. Use iris.experimental.iris_gluon.iris()")
 
         # Gluon only supports the persistent variant
@@ -687,7 +687,7 @@ def all_gather(
                 f"Recommended: block_size_m=8, block_size_n=256."
             )
 
-        context_tensor = shmem.get_device_context()
+        context_tensor = ctx.get_device_context()
 
         persistent_all_gather_gluon[(config.comm_sms,)](
             IrisDeviceCtx,
@@ -726,18 +726,18 @@ def all_gather(
                 f"Please adjust config.comm_sms to be a multiple of {world_size}."
             )
 
-        heap_bases = shmem.get_heap_bases()
+        heap_bases = ctx.get_heap_bases()
 
         if config.all_gather_variant == "ring":
             # Ring variant: allocate ring buffer and flags for producer/consumer sync
-            ring_buffer = shmem.zeros((M, N), dtype=input_tensor.dtype)
+            ring_buffer = ctx.zeros((M, N), dtype=input_tensor.dtype)
 
             num_pid_m = triton.cdiv(M, config.block_size_m)
             num_pid_n = triton.cdiv(N, config.block_size_n)
             total_tiles = num_pid_m * num_pid_n
             flags_per_tile = 1
             total_flags = total_tiles * flags_per_tile
-            flags = shmem.zeros((total_flags,), dtype=torch.int32)
+            flags = ctx.zeros((total_flags,), dtype=torch.int32)
 
             # Calculate next rank in the ring
             if group is None:
@@ -748,7 +748,7 @@ def all_gather(
                 next_rank_in_group = (rank_in_group + 1) % world_size
                 next_rank = group_ranks[next_rank_in_group]
 
-            shmem.barrier()
+            ctx.barrier()
 
             persistent_all_gather_ring[(config.comm_sms,)](
                 input_tensor,
@@ -815,4 +815,4 @@ def all_gather(
             )
 
     if not async_op:
-        shmem.barrier()
+        ctx.barrier()

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -13,7 +13,6 @@ import torch
 import triton
 import triton.language as tl
 import iris
-from iris import DeviceContext, TraceEvent
 from .config import Config
 from .utils import extract_group_info
 

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -563,15 +563,18 @@ def persistent_all_gather_ring(
             # (Triton uses C truncated-division semantics, not Python floored).
             source_rank_idx = (group_rank + world_size - _step) % world_size
 
-            # Wait for next rank's flag to be 0 (ready to receive)
-            # Trace: record the poll as an atomic_cas event on the remote flag
-            h_poll = trace_ctx.tracing.record_event_start(
-                event_id=TraceEvent().atomic_cas,
+            # Trace: record full ring step (poll + store + signal + wait + read + write)
+            # Uses the ring_buffer tile address (2D block) as representative address.
+            h_step = trace_ctx.tracing.record_event_start(
+                event_id=TraceEvent().store,
                 target_rank=next_rank,
-                address=remote_flag_ptr,
+                address=ring_buffer + tile_offset,
                 pid_m=pid_m,
                 pid_n=pid_n,
+                mask=mask,
             )
+
+            # Wait for next rank's flag to be 0 (ready to receive)
             while (
                 iris.atomic_cas(
                     remote_flag_ptr,
@@ -586,17 +589,8 @@ def persistent_all_gather_ring(
                 != 0
             ):
                 pass
-            trace_ctx.tracing.record_event_end(h_poll)
 
             # Write shard into next rank's ring_buffer via iris.store
-            h_store = trace_ctx.tracing.record_event_start(
-                event_id=TraceEvent().store,
-                target_rank=next_rank,
-                address=ring_buffer + tile_offset,
-                pid_m=pid_m,
-                pid_n=pid_n,
-                mask=mask,
-            )
             iris.store(
                 ring_buffer + tile_offset,
                 send_data,
@@ -607,16 +601,8 @@ def persistent_all_gather_ring(
                 hint=(1, BLOCK_SIZE_N),
             )
             tl.debug_barrier()
-            trace_ctx.tracing.record_event_end(h_store)
 
             # Signal next rank that data is ready
-            h_signal = trace_ctx.tracing.record_event_start(
-                event_id=TraceEvent().atomic_xchg,
-                target_rank=next_rank,
-                address=remote_flag_ptr,
-                pid_m=pid_m,
-                pid_n=pid_n,
-            )
             iris.atomic_xchg(
                 remote_flag_ptr,
                 1,
@@ -626,7 +612,6 @@ def persistent_all_gather_ring(
                 sem="release",
                 scope="sys",
             )
-            trace_ctx.tracing.record_event_end(h_signal)
 
             # Wait for our predecessor to deliver data into our ring_buffer
             while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != 1:
@@ -642,6 +627,8 @@ def persistent_all_gather_ring(
             rm_recv = rm + recv_rank_idx * M
             out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
             tl.store(output_ptr + out_offset_recv, recv_tile, mask=mask, cache_modifier=".wt")
+
+            trace_ctx.tracing.record_event_end(h_step)
 
             # Prepare to forward what we just received
             send_data = recv_tile

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -559,9 +559,14 @@ def persistent_all_gather_ring(
             # Wait for next rank's chunk flag to be 0 (ring_buffer is free)
             while (
                 iris.atomic_cas(
-                    remote_flag_ptr, 0, 0,
-                    iris_rank, next_rank, heap_bases,
-                    sem="acquire", scope="sys",
+                    remote_flag_ptr,
+                    0,
+                    0,
+                    iris_rank,
+                    next_rank,
+                    heap_bases,
+                    sem="acquire",
+                    scope="sys",
                 )
                 != 0
             ):
@@ -603,9 +608,13 @@ def persistent_all_gather_ring(
             tl.debug_barrier()
             # Signal next rank: all tiles in chunk are ready
             iris.atomic_xchg(
-                remote_flag_ptr, 1,
-                iris_rank, next_rank, heap_bases,
-                sem="release", scope="sys",
+                remote_flag_ptr,
+                1,
+                iris_rank,
+                next_rank,
+                heap_bases,
+                sem="release",
+                scope="sys",
             )
 
             # === RECEIVE PHASE ===
@@ -680,7 +689,11 @@ def all_gather_preamble(
 
     if config.all_gather_variant == "ring":
         # Single ring buffer for per-chunk handshake
-        if workspace.ring_buffer is None or workspace.ring_buffer.shape != (M, N) or workspace.ring_buffer.dtype != dtype:
+        if (
+            workspace.ring_buffer is None
+            or workspace.ring_buffer.shape != (M, N)
+            or workspace.ring_buffer.dtype != dtype
+        ):
             workspace.ring_buffer = ctx.zeros((M, N), dtype=dtype)
         else:
             workspace.ring_buffer.zero_()

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -29,9 +29,9 @@ class AllGatherWorkspace:
     shape: Tuple[int, int] = ()
     dtype: Optional[torch.dtype] = None
     ring_buffer: Optional[torch.Tensor] = None
-    ring_buffer_1: Optional[torch.Tensor] = None  # Second buffer for double-buffering
     flags: Optional[torch.Tensor] = None
-    flags_per_tile: int = 0
+    num_chunks: int = 0
+    chunk_rows: int = 0
     prepared: bool = False
 
 
@@ -468,8 +468,7 @@ if GLUON_AVAILABLE:
 def persistent_all_gather_ring(
     input_ptr,
     output_ptr,
-    ring_buffer_0,
-    ring_buffer_1,
+    ring_buffer,
     flags,
     M,
     N,
@@ -490,154 +489,157 @@ def persistent_all_gather_ring(
     COMM_SMS: tl.constexpr,
     NUM_XCDS: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
-    FLAGS_PER_TILE: tl.constexpr,
-    context_tensor: tl.tensor = None,
-    TRACING: tl.constexpr = False,
+    NUM_CHUNKS: tl.constexpr,
+    CHUNK_ROWS: tl.constexpr,
 ):
     """
-    Ring-based all-gather with global per-step barrier.
+    Ring-based all-gather with chunked pipelining and per-chunk handshake.
 
-    Each rank starts with its local shard. In step k, rank r forwards
-    the shard received in step k-1 to rank (r+1). After world_size-1
-    steps, every rank has all shards in its output buffer.
+    The shard (M rows x N cols) is split into NUM_CHUNKS row-bands (chunks).
+    Each chunk is CHUNK_ROWS rows x N cols. One flag per chunk controls the
+    producer/consumer handshake, amortizing synchronization cost across all
+    tiles within a chunk.
 
-    Synchronization: uses a global per-step barrier with monotonic counters
-    instead of per-tile flags. All CUs write tiles for a step in parallel,
-    then synchronize once per step via a local done-counter + single remote
-    signal. This reduces remote atomic traffic from O(tiles * steps) to
-    O(steps).
+    CUs are assigned to chunks round-robin: chunk_id = pid % NUM_CHUNKS.
+    Each CU processes all tiles in its assigned chunk across W-1 ring steps.
+    Different CUs work on different chunks at different ring steps, creating
+    a pipeline that keeps XGMI links continuously busy.
 
-    Flags layout (2 int32 values on symmetric heap):
-      flags[0]: send_done — local CUs atomic_add after finishing tiles
-      flags[1]: recv_ready — monotonic counter set by predecessor via
-                iris.atomic_xchg to step number (1, 2, 3, ...).
-                Each CU waits for recv_ready >= current step.
+    Pipeline visualization (4 ranks, 4 chunks):
+      Time →
+      CU0: [chunk0 step0] [chunk0 step1] [chunk0 step2]
+      CU1: [chunk1 step0] [chunk1 step1] [chunk1 step2]
+      CU2: [chunk2 step0] [chunk2 step1] [chunk2 step2]
+      CU3: [chunk3 step0] [chunk3 step1] [chunk3 step2]
+
+    All CUs send/receive concurrently, saturating the ring bandwidth.
+
+    Flags layout: one int32 per chunk on symmetric heap.
+      flag=0 means ring_buffer chunk region is free (producer can write)
+      flag=1 means ring_buffer chunk region has data (consumer can read)
     """
     pid = tl.program_id(0)
 
-    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-    total_tiles = num_pid_m * num_pid_n
-    tl.assume(total_tiles > 0)
+    tiles_per_chunk_m = tl.cdiv(CHUNK_ROWS, BLOCK_SIZE_M)
+    tiles_per_chunk = tiles_per_chunk_m * num_pid_n
 
-    # Barrier flag pointers
-    send_done_ptr = flags + 0  # CUs count here when done sending tiles
-    recv_ready_ptr = flags + 1  # Predecessor writes step number here
+    # Each CU handles one or more chunks round-robin
+    for chunk_id in range(pid, NUM_CHUNKS, COMM_SMS):
+        chunk_row_start = chunk_id * CHUNK_ROWS
 
-    for _step in range(0, world_size - 1):
-        if _step > 0:
-            # Wait for predecessor to deliver data into our ring_buffer
-            # Predecessor sets recv_ready to _step when step _step's data is ready.
-            # Use atomic_cas as a load: compare with 0, swap with 0 — returns current value.
-            while tl.atomic_cas(recv_ready_ptr, 0, 0, sem="acquire", scope="sys") < _step:
-                pass
+        # Flag pointers for this chunk
+        remote_flag_ptr = flags + chunk_id
+        local_flag_ptr = flags + chunk_id
 
-        # --- All CUs process tiles in parallel ---
-        for tile_id in range(pid, total_tiles, COMM_SMS):
-            num_pid_in_group = GROUP_SIZE_M * num_pid_n
-            group_id = tile_id // num_pid_in_group
-            first_pid_m = group_id * GROUP_SIZE_M
-            group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-            pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
-            pid_n = (tile_id % num_pid_in_group) // group_size_m
+        # Step 0: Copy local shard chunk to output
+        for tile_in_chunk in range(tiles_per_chunk):
+            tile_m = tile_in_chunk // num_pid_n
+            tile_n = tile_in_chunk % num_pid_n
 
-            tl.assume(pid_m >= 0)
-            tl.assume(pid_n >= 0)
-            tl.assume(stride_in_m >= 0)
-            tl.assume(stride_in_n >= 0)
-            tl.assume(stride_out_m >= 0)
-            tl.assume(stride_out_n >= 0)
-
-            rm_base = pid_m * BLOCK_SIZE_M
-            rn_base = pid_n * BLOCK_SIZE_N
+            rm_base = chunk_row_start + tile_m * BLOCK_SIZE_M
+            rn_base = tile_n * BLOCK_SIZE_N
             rm = rm_base + tl.arange(0, BLOCK_SIZE_M)
             rn = rn_base + tl.arange(0, BLOCK_SIZE_N)
             rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
             rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
 
             mask = (rm[:, None] < M) & (rn[None, :] < N)
-            tile_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+            in_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+            data = tl.load(input_ptr + in_offset, mask=mask, other=0)
 
-            if _step == 0:
-                # Load from local input
-                send_data = tl.load(input_ptr + tile_offset, mask=mask, other=0)
-                # Write local shard to own output slot
-                rm_out = rm + group_rank * M
-                out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
-                tl.store(output_ptr + out_offset, send_data, mask=mask, cache_modifier=".wt")
-            else:
-                # Load from ring_buffer (predecessor wrote to buf[_step % 2])
-                read_buf = ring_buffer_0 if _step % 2 == 0 else ring_buffer_1
-                send_data = tl.load(read_buf + tile_offset, mask=mask, other=0)
-                # Write to output at the received shard's slot
-                recv_rank_idx = (group_rank + world_size - _step) % world_size
+            # Write to output[group_rank * M + row, col]
+            rm_out = rm + group_rank * M
+            out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
+            tl.store(output_ptr + out_offset, data, mask=mask, cache_modifier=".wt")
+
+        # Ring steps: forward data around the ring
+        for _step in range(0, world_size - 1):
+            # === SEND PHASE ===
+            # Wait for next rank's chunk flag to be 0 (ring_buffer is free)
+            while (
+                iris.atomic_cas(
+                    remote_flag_ptr, 0, 0,
+                    iris_rank, next_rank, heap_bases,
+                    sem="acquire", scope="sys",
+                )
+                != 0
+            ):
+                pass
+
+            # Write all tiles in this chunk to next rank's ring_buffer
+            # Step 0: read from input (own shard), step k>0: read from ring_buffer (received data)
+            for tile_in_chunk in range(tiles_per_chunk):
+                tile_m = tile_in_chunk // num_pid_n
+                tile_n = tile_in_chunk % num_pid_n
+
+                rm_base = chunk_row_start + tile_m * BLOCK_SIZE_M
+                rn_base = tile_n * BLOCK_SIZE_N
+                rm = rm_base + tl.arange(0, BLOCK_SIZE_M)
+                rn = rn_base + tl.arange(0, BLOCK_SIZE_N)
+                rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
+                rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+                mask = (rm[:, None] < M) & (rn[None, :] < N)
+                buf_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+
+                if _step == 0:
+                    # First step: read from input
+                    send_data = tl.load(input_ptr + buf_offset, mask=mask, other=0)
+                else:
+                    # Later steps: read from local ring_buffer (received from predecessor)
+                    send_data = tl.load(ring_buffer + buf_offset, mask=mask, other=0)
+
+                iris.store(
+                    ring_buffer + buf_offset,
+                    send_data,
+                    iris_rank,
+                    next_rank,
+                    heap_bases,
+                    mask=mask,
+                    hint=(1, BLOCK_SIZE_N),
+                )
+
+            tl.debug_barrier()
+            # Signal next rank: all tiles in chunk are ready
+            iris.atomic_xchg(
+                remote_flag_ptr, 1,
+                iris_rank, next_rank, heap_bases,
+                sem="release", scope="sys",
+            )
+
+            # === RECEIVE PHASE ===
+            # Wait for local chunk flag to be 1 (predecessor wrote data)
+            while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != 1:
+                pass
+
+            # Read received data from local ring_buffer and copy to output
+            recv_rank_idx = (group_rank + world_size - _step - 1) % world_size
+
+            for tile_in_chunk in range(tiles_per_chunk):
+                tile_m = tile_in_chunk // num_pid_n
+                tile_n = tile_in_chunk % num_pid_n
+
+                rm_base = chunk_row_start + tile_m * BLOCK_SIZE_M
+                rn_base = tile_n * BLOCK_SIZE_N
+                rm = rm_base + tl.arange(0, BLOCK_SIZE_M)
+                rn = rn_base + tl.arange(0, BLOCK_SIZE_N)
+                rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
+                rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+                mask = (rm[:, None] < M) & (rn[None, :] < N)
+                buf_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+
+                recv_data = tl.load(ring_buffer + buf_offset, mask=mask, other=0)
+
+                # Write to output at the correct rank slot
                 rm_recv = rm + recv_rank_idx * M
                 out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
-                tl.store(output_ptr + out_offset_recv, send_data, mask=mask, cache_modifier=".wt")
+                tl.store(output_ptr + out_offset_recv, recv_data, mask=mask, cache_modifier=".wt")
 
-            # Forward tile to next rank's ring_buffer
-            # Write to buf[(_step + 1) % 2] so next rank can read while we use the other
-            write_buf = ring_buffer_0 if (_step + 1) % 2 == 0 else ring_buffer_1
-            iris.store(
-                write_buf + tile_offset,
-                send_data,
-                iris_rank,
-                next_rank,
-                heap_bases,
-                mask=mask,
-                hint=(1, BLOCK_SIZE_N),
-            )
-
-        # --- Global barrier: all CUs done sending this step ---
-        tl.debug_barrier()
-        done_count = tl.atomic_add(send_done_ptr, 1, sem="release", scope="gpu")
-        if done_count == (_step + 1) * COMM_SMS - 1:
-            # Last CU: signal next rank that step (_step+1) data is ready
-            iris.atomic_xchg(
-                recv_ready_ptr,
-                _step + 1,
-                iris_rank,
-                next_rank,
-                heap_bases,
-                sem="release",
-                scope="sys",
-            )
-
-    # === Final receive: last shard from predecessor, no forwarding ===
-    _last_step = world_size - 1
-    while tl.atomic_cas(recv_ready_ptr, 0, 0, sem="acquire", scope="sys") < _last_step:
-        pass
-
-    for tile_id in range(pid, total_tiles, COMM_SMS):
-        num_pid_in_group = GROUP_SIZE_M * num_pid_n
-        group_id = tile_id // num_pid_in_group
-        first_pid_m = group_id * GROUP_SIZE_M
-        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-        pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
-        pid_n = (tile_id % num_pid_in_group) // group_size_m
-
-        tl.assume(pid_m >= 0)
-        tl.assume(pid_n >= 0)
-
-        rm_base = pid_m * BLOCK_SIZE_M
-        rn_base = pid_n * BLOCK_SIZE_N
-        rm = rm_base + tl.arange(0, BLOCK_SIZE_M)
-        rn = rn_base + tl.arange(0, BLOCK_SIZE_N)
-        rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
-        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
-
-        mask = (rm[:, None] < M) & (rn[None, :] < N)
-        tile_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
-
-        # Final step reads from buf[(world_size - 1) % 2]
-        final_buf = ring_buffer_0 if (world_size - 1) % 2 == 0 else ring_buffer_1
-        recv_data = tl.load(final_buf + tile_offset, mask=mask, other=0)
-
-        # Final shard: goes to slot (group_rank + 1) mod world_size
-        recv_rank_idx = (group_rank + 1) % world_size
-        rm_recv = rm + recv_rank_idx * M
-        out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
-        tl.store(output_ptr + out_offset_recv, recv_data, mask=mask, cache_modifier=".wt")
+            tl.debug_barrier()
+            # Reset local flag to 0 (ring_buffer chunk region is free)
+            tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
 
 
 def all_gather_preamble(
@@ -677,21 +679,28 @@ def all_gather_preamble(
     workspace.prepared = False
 
     if config.all_gather_variant == "ring":
-        workspace.flags_per_tile = 1  # Unused, kept for API compat
+        # Single ring buffer for per-chunk handshake
+        if workspace.ring_buffer is None or workspace.ring_buffer.shape != (M, N) or workspace.ring_buffer.dtype != dtype:
+            workspace.ring_buffer = ctx.zeros((M, N), dtype=dtype)
+        else:
+            workspace.ring_buffer.zero_()
 
-        # Double-buffered ring buffers (alternate per step to avoid WAR hazard)
-        for attr in ("ring_buffer", "ring_buffer_1"):
-            buf = getattr(workspace, attr)
-            if buf is None or buf.shape != (M, N) or buf.dtype != dtype:
-                setattr(workspace, attr, ctx.zeros((M, N), dtype=dtype))
-            else:
-                buf.zero_()
+        # Chunk-based flags: split shard into num_chunks row-bands.
+        # Each chunk gets one flag. More chunks = deeper pipeline but more
+        # flag overhead. Default: use comm_sms chunks (one per CU) clamped
+        # to a reasonable range based on problem size.
+        num_chunks = min(config.comm_sms, max(1, M // config.block_size_m))
+        chunk_rows = (M + num_chunks - 1) // num_chunks
+        # Round up to block boundary for clean tiling
+        chunk_rows = ((chunk_rows + config.block_size_m - 1) // config.block_size_m) * config.block_size_m
+        # Recompute num_chunks based on rounded chunk_rows
+        num_chunks = (M + chunk_rows - 1) // chunk_rows
 
-        # Global barrier uses 2 flags:
-        # [0] = send_done counter, [1] = recv_ready signal (monotonic)
-        total_flags = 2
-        if workspace.flags is None or workspace.flags.numel() != total_flags:
-            workspace.flags = ctx.zeros((total_flags,), dtype=torch.int32)
+        workspace.num_chunks = num_chunks
+        workspace.chunk_rows = chunk_rows
+
+        if workspace.flags is None or workspace.flags.numel() != num_chunks:
+            workspace.flags = ctx.zeros((num_chunks,), dtype=torch.int32)
         else:
             workspace.flags.zero_()
 
@@ -709,7 +718,6 @@ def all_gather(
     async_op=False,
     config=None,
     workspace=None,
-    tracing=False,
 ):
     """
     Internal all-gather collective operation implementation.
@@ -840,17 +848,18 @@ def all_gather(
         if config.all_gather_variant == "ring":
             # Ring variant: use workspace if provided, otherwise allocate
             if workspace is not None and workspace.prepared:
-                ring_buffer_0 = workspace.ring_buffer
-                ring_buffer_1 = workspace.ring_buffer_1
+                ring_buffer = workspace.ring_buffer
                 flags = workspace.flags
-                flags_per_tile = workspace.flags_per_tile
+                num_chunks = workspace.num_chunks
+                chunk_rows = workspace.chunk_rows
                 workspace.prepared = False
             else:
-                ring_buffer_0 = ctx.zeros((M, N), dtype=input_tensor.dtype)
-                ring_buffer_1 = ctx.zeros((M, N), dtype=input_tensor.dtype)
-                flags_per_tile = 1
-                # Global barrier: 2 flags (send_done counter + recv_ready)
-                flags = ctx.zeros((2,), dtype=torch.int32)
+                ring_buffer = ctx.zeros((M, N), dtype=input_tensor.dtype)
+                num_chunks = min(config.comm_sms, max(1, M // config.block_size_m))
+                chunk_rows = (M + num_chunks - 1) // num_chunks
+                chunk_rows = ((chunk_rows + config.block_size_m - 1) // config.block_size_m) * config.block_size_m
+                num_chunks = (M + chunk_rows - 1) // chunk_rows
+                flags = ctx.zeros((num_chunks,), dtype=torch.int32)
                 ctx.barrier()
 
             # Calculate next rank in the ring
@@ -863,14 +872,10 @@ def all_gather(
                 next_rank_in_group = (rank_in_group + 1) % world_size
                 next_rank = group_ranks[next_rank_in_group]
 
-            # Get context tensor for tracing support
-            context_tensor = ctx.get_device_context()
-
             persistent_all_gather_ring[(config.comm_sms,)](
                 input_tensor,
                 output_tensor,
-                ring_buffer_0,
-                ring_buffer_1,
+                ring_buffer,
                 flags,
                 M,
                 N,
@@ -891,9 +896,8 @@ def all_gather(
                 config.comm_sms,
                 config.num_xcds,
                 config.chunk_size,
-                flags_per_tile,
-                context_tensor,
-                tracing,
+                num_chunks,
+                chunk_rows,
                 num_stages=config.num_stages,
                 num_warps=config.num_warps,
                 waves_per_eu=config.waves_per_eu,

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -33,6 +33,7 @@ class AllGatherWorkspace:
     flags_per_tile: int = 0
     prepared: bool = False
 
+
 # Conditional import for Gluon
 try:
     from triton.experimental import gluon

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -510,9 +510,7 @@ def persistent_all_gather_ring(
     TRACING=False due to constexpr dead-code elimination.
     """
     # Initialize DeviceContext for tracing (zero-overhead when TRACING=False)
-    trace_ctx = DeviceContext.initialize(
-        context_tensor, iris_rank, world_size, tracing=TRACING
-    )
+    trace_ctx = DeviceContext.initialize(context_tensor, iris_rank, world_size, tracing=TRACING)
 
     pid = tl.program_id(0)
 

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -446,6 +446,7 @@ if GLUON_AVAILABLE:
 def persistent_all_gather_ring(
     input_ptr,
     output_ptr,
+    ring_buffer,
     flags,
     M,
     N,
@@ -469,19 +470,16 @@ def persistent_all_gather_ring(
     FLAGS_PER_TILE: tl.constexpr,
 ):
     """
-    Ring-based all-gather kernel.
+    Ring-based all-gather kernel using a single-buffer, producer/consumer
+    handshake (same pattern as the ring all-reduce).
 
-    Instead of each rank writing its shard to all N-1 peers (O(N) writes),
-    each rank forwards data around a ring.  In step k, rank r reads the
-    shard that was deposited into its output buffer by its predecessor and
-    iris.store()s it to the next rank's output buffer.  After N-1 steps
-    every rank has all shards.  Total writes per rank: N-1 (one per step),
-    vs N-1 in all-pairs — the same count, but each step only touches one
-    peer, avoiding memory-controller contention from fan-out writes.
+    Each rank starts with its local shard.  In step k (0-indexed), rank r
+    forwards the shard it received in the previous step to rank (r+1) via
+    iris.store into (r+1)'s ring_buffer.  After world_size-1 steps every
+    rank has all shards written into its output buffer.
 
-    Sync: one flag per tile.  The producer writes the shard, then sets the
-    flag to the step number.  The consumer spins until the flag reaches the
-    expected step, reads the shard, and resets the flag for the next step.
+    The ring_buffer is an M x N scratch space on the symmetric heap used
+    for receiving data from the predecessor.
     """
     pid = tl.program_id(0)
 
@@ -512,49 +510,26 @@ def persistent_all_gather_ring(
         rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
         rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
 
-        input_mask = (rm[:, None] < M) & (rn[None, :] < N)
-        input_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+        mask = (rm[:, None] < M) & (rn[None, :] < N)
+        tile_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
 
-        # Step 0: copy local input to output[group_rank * M, :]
-        data = tl.load(input_ptr + input_offset, mask=input_mask, other=0.0)
+        # Load local input tile — this is the first thing we send
+        send_data = tl.load(input_ptr + tile_offset, mask=mask, other=0)
+
+        # Write local shard to local output at group_rank's slot
         rm_out = rm + group_rank * M
-        output_mask = (rm_out[:, None] < (group_rank + 1) * M) & (rn[None, :] < N)
-        combined_mask = input_mask & output_mask
-        out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
-        tl.store(output_ptr + out_offset, data, mask=combined_mask, cache_modifier=".wt")
+        out_offset_local = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
+        tl.store(output_ptr + out_offset_local, send_data, mask=mask, cache_modifier=".wt")
 
         flag_offset = tile_id * FLAGS_PER_TILE
         remote_flag_ptr = flags + flag_offset
         local_flag_ptr = flags + flag_offset
 
-        # Steps 1..world_size-1: forward around the ring
-        for step in range(1, world_size):
-            # The shard we're forwarding: written by our predecessor in the
-            # previous step.  At step k, this is the shard from rank
-            # (group_rank - k + 1) % world_size.
-            source_rank_idx = (group_rank - step + 1) % world_size
+        for _step in range(0, world_size - 1):
+            # Which shard are we forwarding? At step 0, it's our own shard
+            # (group_rank). At step k, it's shard (group_rank - k) % world_size.
+            source_rank_idx = (group_rank - _step) % world_size
 
-            # Read shard from local output buffer
-            rm_src = rm + source_rank_idx * M
-            src_mask = (rm_src[:, None] < (source_rank_idx + 1) * M) & (rn[None, :] < N)
-            src_combined = input_mask & src_mask
-            src_offset = rm_src[:, None] * stride_out_m + rn[None, :] * stride_out_n
-
-            # For step 1, data is from the local copy above (no wait needed).
-            # For step > 1, we must wait for our predecessor to finish writing.
-            if step > 1:
-                # Wait for predecessor to signal that it has written step-1's data
-                while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != step - 1:
-                    pass
-
-            send_data = tl.load(output_ptr + src_offset, mask=src_combined, other=0.0)
-
-            if step > 1:
-                # Reset flag after reading
-                tl.debug_barrier()
-                tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
-
-            # Destination offset on the next rank: same source_rank_idx slot
             # Wait for next rank's flag to be 0 (ready to receive)
             while (
                 iris.atomic_cas(
@@ -571,22 +546,22 @@ def persistent_all_gather_ring(
             ):
                 pass
 
-            # Write shard to next rank's output buffer
+            # Write shard into next rank's ring_buffer via iris.store
             iris.store(
-                output_ptr + src_offset,
+                ring_buffer + tile_offset,
                 send_data,
                 iris_rank,
                 next_rank,
                 heap_bases,
-                mask=src_combined,
+                mask=mask,
                 hint=(1, BLOCK_SIZE_N),
             )
-
-            # Signal next rank: step number as the flag value
             tl.debug_barrier()
+
+            # Signal next rank that data is ready
             iris.atomic_xchg(
                 remote_flag_ptr,
-                step,
+                1,
                 iris_rank,
                 next_rank,
                 heap_bases,
@@ -594,15 +569,23 @@ def persistent_all_gather_ring(
                 scope="sys",
             )
 
-        # After final step, wait for predecessor's last write
-        if world_size > 2:
-            while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != world_size - 1:
-                pass
-            tl.debug_barrier()
-            tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
-        elif world_size == 2:
+            # Wait for our predecessor to deliver data into our ring_buffer
             while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != 1:
                 pass
+
+            # Read received shard from ring_buffer
+            recv_tile = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
+
+            # Write received shard to the correct slot in our output buffer
+            recv_rank_idx = (group_rank - _step - 1) % world_size
+            rm_recv = rm + recv_rank_idx * M
+            out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
+            tl.store(output_ptr + out_offset_recv, recv_tile, mask=mask, cache_modifier=".wt")
+
+            # Prepare to forward what we just received
+            send_data = recv_tile
+
+            # Reset flag for next iteration
             tl.debug_barrier()
             tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
 
@@ -742,7 +725,9 @@ def all_gather(
         heap_bases = shmem.get_heap_bases()
 
         if config.all_gather_variant == "ring":
-            # Ring variant: allocate flags for producer/consumer sync
+            # Ring variant: allocate ring buffer and flags for producer/consumer sync
+            ring_buffer = shmem.zeros((M, N), dtype=input_tensor.dtype)
+
             num_pid_m = triton.cdiv(M, config.block_size_m)
             num_pid_n = triton.cdiv(N, config.block_size_n)
             total_tiles = num_pid_m * num_pid_n
@@ -764,6 +749,7 @@ def all_gather(
             persistent_all_gather_ring[(config.comm_sms,)](
                 input_tensor,
                 output_tensor,
+                ring_buffer,
                 flags,
                 M,
                 N,

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -528,7 +528,9 @@ def persistent_all_gather_ring(
         for _step in range(0, world_size - 1):
             # Which shard are we forwarding? At step 0, it's our own shard
             # (group_rank). At step k, it's shard (group_rank - k) % world_size.
-            source_rank_idx = (group_rank - _step) % world_size
+            # Note: add world_size before modulo to avoid negative values
+            # (Triton uses C truncated-division semantics, not Python floored).
+            source_rank_idx = (group_rank + world_size - _step) % world_size
 
             # Wait for next rank's flag to be 0 (ready to receive)
             while (
@@ -577,7 +579,9 @@ def persistent_all_gather_ring(
             recv_tile = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
 
             # Write received shard to the correct slot in our output buffer
-            recv_rank_idx = (group_rank - _step - 1) % world_size
+            # Note: add world_size before modulo to avoid negative values
+            # (Triton uses C truncated-division semantics, not Python floored).
+            recv_rank_idx = (group_rank + world_size - _step - 1) % world_size
             rm_recv = rm + recv_rank_idx * M
             out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
             tl.store(output_ptr + out_offset_recv, recv_tile, mask=mask, cache_modifier=".wt")

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -553,7 +553,19 @@ def persistent_all_gather_ring(
             out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
             tl.store(output_ptr + out_offset, data, mask=mask, cache_modifier=".wt")
 
-        # Ring steps: forward data around the ring
+        # Ring steps: forward data around the ring.
+        #
+        # Critical invariant: we must NOT reset the local flag (allowing the
+        # predecessor to overwrite ring_buffer) until AFTER we've read ring_buffer
+        # for forwarding in the send phase. The sequence per step is:
+        #
+        #   1. SEND: read data (input at step 0, ring_buffer at step>0),
+        #      write to next rank's ring_buffer, signal next rank
+        #   2. Release ring_buffer from previous step (reset flag, step>0 only)
+        #   3. RECV: wait for predecessor's data, read ring_buffer, write to output
+        #   4. Do NOT reset flag yet — ring_buffer data needed for next step's send
+        #
+        # After the last step, reset the flag for cleanup.
         for _step in range(0, world_size - 1):
             # === SEND PHASE ===
             # Wait for next rank's chunk flag to be 0 (ring_buffer is free)
@@ -572,8 +584,10 @@ def persistent_all_gather_ring(
             ):
                 pass
 
-            # Write all tiles in this chunk to next rank's ring_buffer
-            # Step 0: read from input (own shard), step k>0: read from ring_buffer (received data)
+            # Write all tiles in this chunk to next rank's ring_buffer.
+            # Step 0: read from input (own shard)
+            # Step k>0: read from local ring_buffer (received from predecessor,
+            #   still valid because we haven't reset the local flag yet)
             for tile_in_chunk in range(tiles_per_chunk):
                 tile_m = tile_in_chunk // num_pid_n
                 tile_n = tile_in_chunk % num_pid_n
@@ -589,10 +603,8 @@ def persistent_all_gather_ring(
                 buf_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
 
                 if _step == 0:
-                    # First step: read from input
                     send_data = tl.load(input_ptr + buf_offset, mask=mask, other=0)
                 else:
-                    # Later steps: read from local ring_buffer (received from predecessor)
                     send_data = tl.load(ring_buffer + buf_offset, mask=mask, other=0)
 
                 iris.store(
@@ -616,6 +628,13 @@ def persistent_all_gather_ring(
                 sem="release",
                 scope="sys",
             )
+
+            # === RELEASE PREVIOUS STEP'S RING BUFFER ===
+            # We've finished reading ring_buffer for forwarding. Now safe to
+            # let the predecessor overwrite it for the next step.
+            if _step > 0:
+                tl.debug_barrier()
+                tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
 
             # === RECEIVE PHASE ===
             # Wait for local chunk flag to be 1 (predecessor wrote data)
@@ -646,9 +665,11 @@ def persistent_all_gather_ring(
                 out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
                 tl.store(output_ptr + out_offset_recv, recv_data, mask=mask, cache_modifier=".wt")
 
-            tl.debug_barrier()
-            # Reset local flag to 0 (ring_buffer chunk region is free)
-            tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
+            # Do NOT reset flag here — ring_buffer data is needed for next step's send.
+
+        # Final cleanup: release ring_buffer from last step
+        tl.debug_barrier()
+        tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
 
 
 def all_gather_preamble(

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -494,30 +494,118 @@ def persistent_all_gather_ring(
     TRACING: tl.constexpr = False,
 ):
     """
-    Ring-based all-gather kernel using a single-buffer, producer/consumer
-    handshake (same pattern as the ring all-reduce).
+    Ring-based all-gather with global per-step barrier.
 
-    Each rank starts with its local shard.  In step k (0-indexed), rank r
-    forwards the shard it received in the previous step to rank (r+1) via
-    iris.store into (r+1)'s ring_buffer.  After world_size-1 steps every
-    rank has all shards written into its output buffer.
+    Each rank starts with its local shard. In step k, rank r forwards
+    the shard received in step k-1 to rank (r+1). After world_size-1
+    steps, every rank has all shards in its output buffer.
 
-    The ring_buffer is an M x N scratch space on the symmetric heap used
-    for receiving data from the predecessor.
+    Synchronization: uses a global per-step barrier instead of per-tile
+    flags. All CUs write tiles for a step in parallel, then synchronize
+    once per step. This reduces remote atomic traffic from O(tiles * steps)
+    to O(steps).
 
-    When TRACING=True, records iris tracing events for remote operations
-    (iris.atomic_cas, iris.store, iris.atomic_xchg). Zero overhead when
-    TRACING=False due to constexpr dead-code elimination.
+    Flags layout (3 int32 values on symmetric heap):
+      flags[0]: send_done counter — local CUs atomic_add after finishing tiles
+      flags[1]: recv_ready — set by predecessor after all its tiles are sent
+      flags[2]: next rank's recv_ready target (written via iris.atomic_xchg)
     """
-    # Initialize DeviceContext for tracing (zero-overhead when TRACING=False)
-    trace_ctx = DeviceContext.initialize(context_tensor, iris_rank, world_size, tracing=TRACING)
-
     pid = tl.program_id(0)
 
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     total_tiles = num_pid_m * num_pid_n
     tl.assume(total_tiles > 0)
+
+    # Barrier flag pointers
+    send_done_ptr = flags + 0  # CUs count here when done sending tiles
+    recv_ready_ptr = flags + 1  # Predecessor sets this when its data is ready
+
+    for _step in range(0, world_size - 1):
+        # Which shard are we forwarding?
+        # Step 0: our own shard (group_rank). Step k: shard (group_rank - k).
+        # Add world_size before modulo to avoid negative values
+        # (Triton uses C truncated-division semantics, not Python floored).
+        source_rank_idx = (group_rank + world_size - _step) % world_size
+
+        if _step > 0:
+            # Wait for predecessor to deliver data into our ring_buffer
+            while tl.atomic_cas(recv_ready_ptr, 1, 1, sem="acquire", scope="sys") != 1:
+                pass
+
+        # --- All CUs process tiles in parallel ---
+        for tile_id in range(pid, total_tiles, COMM_SMS):
+            num_pid_in_group = GROUP_SIZE_M * num_pid_n
+            group_id = tile_id // num_pid_in_group
+            first_pid_m = group_id * GROUP_SIZE_M
+            group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+            pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+            pid_n = (tile_id % num_pid_in_group) // group_size_m
+
+            tl.assume(pid_m >= 0)
+            tl.assume(pid_n >= 0)
+            tl.assume(stride_in_m >= 0)
+            tl.assume(stride_in_n >= 0)
+            tl.assume(stride_out_m >= 0)
+            tl.assume(stride_out_n >= 0)
+
+            rm_base = pid_m * BLOCK_SIZE_M
+            rn_base = pid_n * BLOCK_SIZE_N
+            rm = rm_base + tl.arange(0, BLOCK_SIZE_M)
+            rn = rn_base + tl.arange(0, BLOCK_SIZE_N)
+            rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
+            rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+            mask = (rm[:, None] < M) & (rn[None, :] < N)
+            tile_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+
+            if _step == 0:
+                # Load from local input
+                send_data = tl.load(input_ptr + tile_offset, mask=mask, other=0)
+                # Write local shard to own output slot
+                rm_out = rm + group_rank * M
+                out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
+                tl.store(output_ptr + out_offset, send_data, mask=mask, cache_modifier=".wt")
+            else:
+                # Load from ring_buffer (data from predecessor)
+                send_data = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
+                # Write to output at the received shard's slot
+                recv_rank_idx = (group_rank + world_size - _step) % world_size
+                rm_recv = rm + recv_rank_idx * M
+                out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
+                tl.store(output_ptr + out_offset_recv, send_data, mask=mask, cache_modifier=".wt")
+
+            # Forward tile to next rank's ring_buffer
+            iris.store(
+                ring_buffer + tile_offset,
+                send_data,
+                iris_rank,
+                next_rank,
+                heap_bases,
+                mask=mask,
+                hint=(1, BLOCK_SIZE_N),
+            )
+
+        # --- Global barrier: all CUs done sending this step ---
+        tl.debug_barrier()
+        done_count = tl.atomic_add(send_done_ptr, 1, sem="release", scope="gpu")
+        if done_count == (_step + 1) * COMM_SMS - 1:
+            # Last CU: reset recv_ready for next step, signal next rank
+            if _step > 0:
+                tl.atomic_xchg(recv_ready_ptr, 0, sem="release", scope="sys")
+            iris.atomic_xchg(
+                recv_ready_ptr,
+                1,
+                iris_rank,
+                next_rank,
+                heap_bases,
+                sem="release",
+                scope="sys",
+            )
+
+    # === Final receive: last shard from predecessor, no forwarding ===
+    while tl.atomic_cas(recv_ready_ptr, 1, 1, sem="acquire", scope="sys") != 1:
+        pass
 
     for tile_id in range(pid, total_tiles, COMM_SMS):
         num_pid_in_group = GROUP_SIZE_M * num_pid_n
@@ -529,10 +617,6 @@ def persistent_all_gather_ring(
 
         tl.assume(pid_m >= 0)
         tl.assume(pid_n >= 0)
-        tl.assume(stride_in_m >= 0)
-        tl.assume(stride_in_n >= 0)
-        tl.assume(stride_out_m >= 0)
-        tl.assume(stride_out_n >= 0)
 
         rm_base = pid_m * BLOCK_SIZE_M
         rn_base = pid_n * BLOCK_SIZE_N
@@ -544,98 +628,13 @@ def persistent_all_gather_ring(
         mask = (rm[:, None] < M) & (rn[None, :] < N)
         tile_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
 
-        # Load local input tile — this is the first thing we send
-        send_data = tl.load(input_ptr + tile_offset, mask=mask, other=0)
+        recv_data = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
 
-        # Write local shard to local output at group_rank's slot
-        rm_out = rm + group_rank * M
-        out_offset_local = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
-        tl.store(output_ptr + out_offset_local, send_data, mask=mask, cache_modifier=".wt")
-
-        flag_offset = tile_id * FLAGS_PER_TILE
-        remote_flag_ptr = flags + flag_offset
-        local_flag_ptr = flags + flag_offset
-
-        for _step in range(0, world_size - 1):
-            # Which shard are we forwarding? At step 0, it's our own shard
-            # (group_rank). At step k, it's shard (group_rank - k) % world_size.
-            # Note: add world_size before modulo to avoid negative values
-            # (Triton uses C truncated-division semantics, not Python floored).
-            source_rank_idx = (group_rank + world_size - _step) % world_size
-
-            # Trace: record full ring step (poll + store + signal + wait + read + write)
-            # Uses the ring_buffer tile address (2D block) as representative address.
-            h_step = trace_ctx.tracing.record_event_start(
-                event_id=TraceEvent().store,
-                target_rank=next_rank,
-                address=ring_buffer + tile_offset,
-                pid_m=pid_m,
-                pid_n=pid_n,
-                mask=mask,
-            )
-
-            # Wait for next rank's flag to be 0 (ready to receive)
-            while (
-                iris.atomic_cas(
-                    remote_flag_ptr,
-                    0,
-                    0,
-                    iris_rank,
-                    next_rank,
-                    heap_bases,
-                    sem="acquire",
-                    scope="sys",
-                )
-                != 0
-            ):
-                pass
-
-            # Write shard into next rank's ring_buffer via iris.store
-            iris.store(
-                ring_buffer + tile_offset,
-                send_data,
-                iris_rank,
-                next_rank,
-                heap_bases,
-                mask=mask,
-                hint=(1, BLOCK_SIZE_N),
-            )
-            tl.debug_barrier()
-
-            # Signal next rank that data is ready
-            iris.atomic_xchg(
-                remote_flag_ptr,
-                1,
-                iris_rank,
-                next_rank,
-                heap_bases,
-                sem="release",
-                scope="sys",
-            )
-
-            # Wait for our predecessor to deliver data into our ring_buffer
-            while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != 1:
-                pass
-
-            # Read received shard from ring_buffer
-            recv_tile = tl.load(ring_buffer + tile_offset, mask=mask, other=0)
-
-            # Write received shard to the correct slot in our output buffer
-            # Note: add world_size before modulo to avoid negative values
-            # (Triton uses C truncated-division semantics, not Python floored).
-            recv_rank_idx = (group_rank + world_size - _step - 1) % world_size
-            rm_recv = rm + recv_rank_idx * M
-            out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
-            tl.store(output_ptr + out_offset_recv, recv_tile, mask=mask, cache_modifier=".wt")
-
-            trace_ctx.tracing.record_event_end(h_step)
-
-            # Prepare to forward what we just received
-            send_data = recv_tile
-
-            # Reset flag for next iteration
-            tl.debug_barrier()
-            tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
+        # Final shard: goes to slot (group_rank - (world_size-1)) mod world_size
+        recv_rank_idx = (group_rank + 1) % world_size
+        rm_recv = rm + recv_rank_idx * M
+        out_offset_recv = rm_recv[:, None] * stride_out_m + rn[None, :] * stride_out_n
+        tl.store(output_ptr + out_offset_recv, recv_data, mask=mask, cache_modifier=".wt")
 
 
 def all_gather_preamble(
@@ -675,11 +674,7 @@ def all_gather_preamble(
     workspace.prepared = False
 
     if config.all_gather_variant == "ring":
-        num_pid_m = triton.cdiv(M, config.block_size_m)
-        num_pid_n = triton.cdiv(N, config.block_size_n)
-        total_tiles = num_pid_m * num_pid_n
-        workspace.flags_per_tile = 1
-        total_flags = total_tiles * workspace.flags_per_tile
+        workspace.flags_per_tile = 1  # Unused, kept for API compat
 
         if (
             workspace.ring_buffer is None
@@ -690,6 +685,9 @@ def all_gather_preamble(
         else:
             workspace.ring_buffer.zero_()
 
+        # Global barrier uses 2 flags:
+        # [0] = send_done counter, [1] = recv_ready signal
+        total_flags = 2
         if workspace.flags is None or workspace.flags.numel() != total_flags:
             workspace.flags = ctx.zeros((total_flags,), dtype=torch.int32)
         else:
@@ -846,12 +844,9 @@ def all_gather(
                 workspace.prepared = False
             else:
                 ring_buffer = ctx.zeros((M, N), dtype=input_tensor.dtype)
-                num_pid_m = triton.cdiv(M, config.block_size_m)
-                num_pid_n = triton.cdiv(N, config.block_size_n)
-                total_tiles = num_pid_m * num_pid_n
                 flags_per_tile = 1
-                total_flags = total_tiles * flags_per_tile
-                flags = ctx.zeros((total_flags,), dtype=torch.int32)
+                # Global barrier: 2 flags (send_done counter + recv_ready)
+                flags = ctx.zeros((2,), dtype=torch.int32)
                 ctx.barrier()
 
             # Calculate next rank in the ring

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -744,6 +744,7 @@ def all_gather(
                 next_rank = (rank_in_group + 1) % world_size
             else:
                 import torch.distributed as dist
+
                 group_ranks = dist.get_process_group_ranks(group)
                 next_rank_in_group = (rank_in_group + 1) % world_size
                 next_rank = group_ranks[next_rank_in_group]

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -13,6 +13,7 @@ import torch
 import triton
 import triton.language as tl
 import iris
+from iris import DeviceContext, TraceEvent
 from .config import Config
 from .utils import extract_group_info
 
@@ -489,6 +490,8 @@ def persistent_all_gather_ring(
     NUM_XCDS: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
     FLAGS_PER_TILE: tl.constexpr,
+    context_tensor: tl.tensor = None,
+    TRACING: tl.constexpr = False,
 ):
     """
     Ring-based all-gather kernel using a single-buffer, producer/consumer
@@ -501,7 +504,16 @@ def persistent_all_gather_ring(
 
     The ring_buffer is an M x N scratch space on the symmetric heap used
     for receiving data from the predecessor.
+
+    When TRACING=True, records iris tracing events for remote operations
+    (iris.atomic_cas, iris.store, iris.atomic_xchg). Zero overhead when
+    TRACING=False due to constexpr dead-code elimination.
     """
+    # Initialize DeviceContext for tracing (zero-overhead when TRACING=False)
+    trace_ctx = DeviceContext.initialize(
+        context_tensor, iris_rank, world_size, tracing=TRACING
+    )
+
     pid = tl.program_id(0)
 
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -554,6 +566,14 @@ def persistent_all_gather_ring(
             source_rank_idx = (group_rank + world_size - _step) % world_size
 
             # Wait for next rank's flag to be 0 (ready to receive)
+            # Trace: record the poll as an atomic_cas event on the remote flag
+            h_poll = trace_ctx.tracing.record_event_start(
+                event_id=TraceEvent().atomic_cas,
+                target_rank=next_rank,
+                address=remote_flag_ptr,
+                pid_m=pid_m,
+                pid_n=pid_n,
+            )
             while (
                 iris.atomic_cas(
                     remote_flag_ptr,
@@ -568,8 +588,17 @@ def persistent_all_gather_ring(
                 != 0
             ):
                 pass
+            trace_ctx.tracing.record_event_end(h_poll)
 
             # Write shard into next rank's ring_buffer via iris.store
+            h_store = trace_ctx.tracing.record_event_start(
+                event_id=TraceEvent().store,
+                target_rank=next_rank,
+                address=ring_buffer + tile_offset,
+                pid_m=pid_m,
+                pid_n=pid_n,
+                mask=mask,
+            )
             iris.store(
                 ring_buffer + tile_offset,
                 send_data,
@@ -580,8 +609,16 @@ def persistent_all_gather_ring(
                 hint=(1, BLOCK_SIZE_N),
             )
             tl.debug_barrier()
+            trace_ctx.tracing.record_event_end(h_store)
 
             # Signal next rank that data is ready
+            h_signal = trace_ctx.tracing.record_event_start(
+                event_id=TraceEvent().atomic_xchg,
+                target_rank=next_rank,
+                address=remote_flag_ptr,
+                pid_m=pid_m,
+                pid_n=pid_n,
+            )
             iris.atomic_xchg(
                 remote_flag_ptr,
                 1,
@@ -591,6 +628,7 @@ def persistent_all_gather_ring(
                 sem="release",
                 scope="sys",
             )
+            trace_ctx.tracing.record_event_end(h_signal)
 
             # Wait for our predecessor to deliver data into our ring_buffer
             while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != 1:
@@ -686,6 +724,7 @@ def all_gather(
     async_op=False,
     config=None,
     workspace=None,
+    tracing=False,
 ):
     """
     Internal all-gather collective operation implementation.
@@ -840,6 +879,9 @@ def all_gather(
                 next_rank_in_group = (rank_in_group + 1) % world_size
                 next_rank = group_ranks[next_rank_in_group]
 
+            # Get context tensor for tracing support
+            context_tensor = ctx.get_device_context()
+
             persistent_all_gather_ring[(config.comm_sms,)](
                 input_tensor,
                 output_tensor,
@@ -865,6 +907,8 @@ def all_gather(
                 config.num_xcds,
                 config.chunk_size,
                 flags_per_tile,
+                context_tensor,
+                tracing,
                 num_stages=config.num_stages,
                 num_warps=config.num_warps,
                 waves_per_eu=config.waves_per_eu,

--- a/iris/ccl/all_gather.py
+++ b/iris/ccl/all_gather.py
@@ -6,6 +6,7 @@ All-gather collective communication primitive for Iris.
 Gathers tensors from all ranks and concatenates them along the last dimension.
 """
 
+import torch
 import triton
 import triton.language as tl
 import iris
@@ -441,6 +442,171 @@ if GLUON_AVAILABLE:
                     gl.store(remote_ptrs, data, mask=mask)
 
 
+@triton.jit()
+def persistent_all_gather_ring(
+    input_ptr,
+    output_ptr,
+    flags,
+    M,
+    N,
+    stride_in_m,
+    stride_in_n,
+    stride_out_m,
+    stride_out_n,
+    heap_bases: tl.tensor,
+    group_rank: tl.constexpr,
+    iris_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    rank_start: tl.constexpr,
+    rank_stride: tl.constexpr,
+    next_rank: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    COMM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    FLAGS_PER_TILE: tl.constexpr,
+):
+    """
+    Ring-based all-gather kernel.
+
+    Instead of each rank writing its shard to all N-1 peers (O(N) writes),
+    each rank forwards data around a ring.  In step k, rank r reads the
+    shard that was deposited into its output buffer by its predecessor and
+    iris.store()s it to the next rank's output buffer.  After N-1 steps
+    every rank has all shards.  Total writes per rank: N-1 (one per step),
+    vs N-1 in all-pairs — the same count, but each step only touches one
+    peer, avoiding memory-controller contention from fan-out writes.
+
+    Sync: one flag per tile.  The producer writes the shard, then sets the
+    flag to the step number.  The consumer spins until the flag reaches the
+    expected step, reads the shard, and resets the flag for the next step.
+    """
+    pid = tl.program_id(0)
+
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    total_tiles = num_pid_m * num_pid_n
+    tl.assume(total_tiles > 0)
+
+    for tile_id in range(pid, total_tiles, COMM_SMS):
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = tile_id // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+        pid_n = (tile_id % num_pid_in_group) // group_size_m
+
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+        tl.assume(stride_in_m >= 0)
+        tl.assume(stride_in_n >= 0)
+        tl.assume(stride_out_m >= 0)
+        tl.assume(stride_out_n >= 0)
+
+        rm_base = pid_m * BLOCK_SIZE_M
+        rn_base = pid_n * BLOCK_SIZE_N
+        rm = rm_base + tl.arange(0, BLOCK_SIZE_M)
+        rn = rn_base + tl.arange(0, BLOCK_SIZE_N)
+        rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
+        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+        input_mask = (rm[:, None] < M) & (rn[None, :] < N)
+        input_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+
+        # Step 0: copy local input to output[group_rank * M, :]
+        data = tl.load(input_ptr + input_offset, mask=input_mask, other=0.0)
+        rm_out = rm + group_rank * M
+        output_mask = (rm_out[:, None] < (group_rank + 1) * M) & (rn[None, :] < N)
+        combined_mask = input_mask & output_mask
+        out_offset = rm_out[:, None] * stride_out_m + rn[None, :] * stride_out_n
+        tl.store(output_ptr + out_offset, data, mask=combined_mask, cache_modifier=".wt")
+
+        flag_offset = tile_id * FLAGS_PER_TILE
+        remote_flag_ptr = flags + flag_offset
+        local_flag_ptr = flags + flag_offset
+
+        # Steps 1..world_size-1: forward around the ring
+        for step in range(1, world_size):
+            # The shard we're forwarding: written by our predecessor in the
+            # previous step.  At step k, this is the shard from rank
+            # (group_rank - k + 1) % world_size.
+            source_rank_idx = (group_rank - step + 1) % world_size
+
+            # Read shard from local output buffer
+            rm_src = rm + source_rank_idx * M
+            src_mask = (rm_src[:, None] < (source_rank_idx + 1) * M) & (rn[None, :] < N)
+            src_combined = input_mask & src_mask
+            src_offset = rm_src[:, None] * stride_out_m + rn[None, :] * stride_out_n
+
+            # For step 1, data is from the local copy above (no wait needed).
+            # For step > 1, we must wait for our predecessor to finish writing.
+            if step > 1:
+                # Wait for predecessor to signal that it has written step-1's data
+                while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != step - 1:
+                    pass
+
+            send_data = tl.load(output_ptr + src_offset, mask=src_combined, other=0.0)
+
+            if step > 1:
+                # Reset flag after reading
+                tl.debug_barrier()
+                tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
+
+            # Destination offset on the next rank: same source_rank_idx slot
+            # Wait for next rank's flag to be 0 (ready to receive)
+            while (
+                iris.atomic_cas(
+                    remote_flag_ptr,
+                    0,
+                    0,
+                    iris_rank,
+                    next_rank,
+                    heap_bases,
+                    sem="acquire",
+                    scope="sys",
+                )
+                != 0
+            ):
+                pass
+
+            # Write shard to next rank's output buffer
+            iris.store(
+                output_ptr + src_offset,
+                send_data,
+                iris_rank,
+                next_rank,
+                heap_bases,
+                mask=src_combined,
+                hint=(1, BLOCK_SIZE_N),
+            )
+
+            # Signal next rank: step number as the flag value
+            tl.debug_barrier()
+            iris.atomic_xchg(
+                remote_flag_ptr,
+                step,
+                iris_rank,
+                next_rank,
+                heap_bases,
+                sem="release",
+                scope="sys",
+            )
+
+        # After final step, wait for predecessor's last write
+        if world_size > 2:
+            while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != world_size - 1:
+                pass
+            tl.debug_barrier()
+            tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
+        elif world_size == 2:
+            while tl.atomic_cas(local_flag_ptr, 0, 0, sem="acquire", scope="sys") != 1:
+                pass
+            tl.debug_barrier()
+            tl.atomic_xchg(local_flag_ptr, 0, sem="release", scope="sys")
+
+
 def all_gather(
     output_tensor,
     input_tensor,
@@ -500,7 +666,7 @@ def all_gather(
             raise ValueError("use_gluon=True requires Iris Gluon context. Use iris.experimental.iris_gluon.iris()")
 
         # Gluon only supports the persistent variant
-        if config.all_gather_variant != "persistent":
+        if config.all_gather_variant not in ("persistent",):
             raise ValueError(
                 f"Gluon all_gather only supports all_gather_variant='persistent', got '{config.all_gather_variant}'."
             )
@@ -575,39 +741,88 @@ def all_gather(
 
         heap_bases = shmem.get_heap_bases()
 
-        # Dispatch to the appropriate kernel based on variant
-        if config.all_gather_variant == "persistent":
-            kernel_fn = persistent_all_gather
-        elif config.all_gather_variant == "partitioned":
-            kernel_fn = persistent_all_gather_partitioned
-        else:
-            raise ValueError(f"Unknown all_gather_variant: {config.all_gather_variant}")
+        if config.all_gather_variant == "ring":
+            # Ring variant: allocate flags for producer/consumer sync
+            num_pid_m = triton.cdiv(M, config.block_size_m)
+            num_pid_n = triton.cdiv(N, config.block_size_n)
+            total_tiles = num_pid_m * num_pid_n
+            flags_per_tile = 1
+            total_flags = total_tiles * flags_per_tile
+            flags = shmem.zeros((total_flags,), dtype=torch.int32)
 
-        kernel_fn[(config.comm_sms,)](
-            input_tensor,
-            output_tensor,
-            M,
-            N,
-            stride_in_m,
-            stride_in_n,
-            stride_out_m,
-            stride_out_n,
-            heap_bases,
-            rank_in_group,
-            rank_global,
-            world_size,
-            rank_start,
-            rank_stride,
-            config.block_size_m,
-            config.block_size_n,
-            config.swizzle_size,
-            config.comm_sms,
-            config.num_xcds,
-            config.chunk_size,
-            num_stages=config.num_stages,
-            num_warps=config.num_warps,
-            waves_per_eu=config.waves_per_eu,
-        )
+            # Calculate next rank in the ring
+            if group is None:
+                next_rank = (rank_in_group + 1) % world_size
+            else:
+                import torch.distributed as dist
+                group_ranks = dist.get_process_group_ranks(group)
+                next_rank_in_group = (rank_in_group + 1) % world_size
+                next_rank = group_ranks[next_rank_in_group]
+
+            shmem.barrier()
+
+            persistent_all_gather_ring[(config.comm_sms,)](
+                input_tensor,
+                output_tensor,
+                flags,
+                M,
+                N,
+                stride_in_m,
+                stride_in_n,
+                stride_out_m,
+                stride_out_n,
+                heap_bases,
+                rank_in_group,
+                rank_global,
+                world_size,
+                rank_start,
+                rank_stride,
+                next_rank,
+                config.block_size_m,
+                config.block_size_n,
+                config.swizzle_size,
+                config.comm_sms,
+                config.num_xcds,
+                config.chunk_size,
+                flags_per_tile,
+                num_stages=config.num_stages,
+                num_warps=config.num_warps,
+                waves_per_eu=config.waves_per_eu,
+            )
+        else:
+            # Dispatch to the appropriate kernel based on variant
+            if config.all_gather_variant == "persistent":
+                kernel_fn = persistent_all_gather
+            elif config.all_gather_variant == "partitioned":
+                kernel_fn = persistent_all_gather_partitioned
+            else:
+                raise ValueError(f"Unknown all_gather_variant: {config.all_gather_variant}")
+
+            kernel_fn[(config.comm_sms,)](
+                input_tensor,
+                output_tensor,
+                M,
+                N,
+                stride_in_m,
+                stride_in_n,
+                stride_out_m,
+                stride_out_n,
+                heap_bases,
+                rank_in_group,
+                rank_global,
+                world_size,
+                rank_start,
+                rank_stride,
+                config.block_size_m,
+                config.block_size_n,
+                config.swizzle_size,
+                config.comm_sms,
+                config.num_xcds,
+                config.chunk_size,
+                num_stages=config.num_stages,
+                num_warps=config.num_warps,
+                waves_per_eu=config.waves_per_eu,
+            )
 
     if not async_op:
         shmem.barrier()

--- a/iris/ccl/config.py
+++ b/iris/ccl/config.py
@@ -32,9 +32,10 @@ class Config:
         use_gluon: If True, use Gluon-based implementation (default: False)
                    Gluon provides better control over warp-level traffic shaping
         all_gather_variant: Variant for all-gather operation (default: "persistent")
-                           Options: "persistent", "partitioned"
+                           Options: "persistent", "partitioned", "ring"
                            - "persistent": Each PID handles multiple tiles and sends to all ranks
                            - "partitioned": PIDs partitioned across ranks, eliminates inner loop
+                           - "ring": Ring-based forwarding with flag sync, O(1) writes per step
         all_reduce_variant: Variant for all-reduce operation (default: "atomic")
                            Options: "atomic", "ring", "two_shot", "one_shot", "spinlock"
         all_reduce_distribution: Distribution for two-shot all-reduce (default: 0)
@@ -84,7 +85,7 @@ class Config:
     num_xcds: int | None = None
     chunk_size: int | None = None
     use_gluon: bool = False
-    all_gather_variant: str = "persistent"
+    all_gather_variant: str = "persistent"  # "persistent", "partitioned", or "ring"
     all_reduce_variant: str = "two_shot"
     all_reduce_distribution: int = 1
     all_reduce_num_rings: int = 1
@@ -114,9 +115,9 @@ class Config:
             raise ValueError(f"comm_sms must be positive, got {self.comm_sms}")
         if self.num_xcds <= 0:
             raise ValueError(f"num_xcds must be positive, got {self.num_xcds}")
-        if self.all_gather_variant not in ["persistent", "partitioned"]:
+        if self.all_gather_variant not in ["persistent", "partitioned", "ring"]:
             raise ValueError(
-                f"all_gather_variant must be one of: 'persistent', 'partitioned', got {self.all_gather_variant}"
+                f"all_gather_variant must be one of: 'persistent', 'partitioned', 'ring', got {self.all_gather_variant}"
             )
         if self.all_reduce_variant not in ["atomic", "ring", "two_shot", "one_shot", "spinlock"]:
             raise ValueError(

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -1192,7 +1192,15 @@ class Iris:
             """
             from iris.ccl.all_gather import all_gather as _all_gather
 
-            _all_gather(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config, workspace=workspace)
+            _all_gather(
+                output_tensor,
+                input_tensor,
+                self._iris,
+                group=group,
+                async_op=async_op,
+                config=config,
+                workspace=workspace,
+            )
 
         def all_gather_preamble(self, output_tensor, input_tensor, config=None, workspace=None):
             """

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -1160,7 +1160,7 @@ class Iris:
             _all_to_all(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config)
 
         def all_gather(
-            self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None, tracing=False
+            self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None
         ):
             """
             All-gather collective operation.
@@ -1180,8 +1180,6 @@ class Iris:
                         If None, uses default Config values.
                 workspace: Optional AllGatherWorkspace from ``all_gather_preamble``.
                            Avoids per-call heap allocation for ring variant.
-                tracing: Enable iris tracing for remote operations (default: False).
-                         Zero overhead when disabled.
 
             Example:
                 >>> ctx = iris.iris()
@@ -1193,11 +1191,6 @@ class Iris:
                 >>> config = Config(all_gather_variant="ring")
                 >>> ws = ctx.ccl.all_gather_preamble(out, inp, config=config)
                 >>> ctx.ccl.all_gather(out, inp, config=config, workspace=ws)
-
-                >>> # With tracing enabled
-                >>> ctx.tracing.enable(max_events=1_000_000)
-                >>> ctx.ccl.all_gather(out, inp, config=config, tracing=True)
-                >>> ctx.tracing.export("ring_trace.json")
             """
             from iris.ccl.all_gather import all_gather as _all_gather
 
@@ -1209,7 +1202,6 @@ class Iris:
                 async_op=async_op,
                 config=config,
                 workspace=workspace,
-                tracing=tracing,
             )
 
         def all_gather_preamble(self, output_tensor, input_tensor, config=None, workspace=None):

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -1159,9 +1159,7 @@ class Iris:
 
             _all_to_all(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config)
 
-        def all_gather(
-            self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None
-        ):
+        def all_gather(self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None):
             """
             All-gather collective operation.
 

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -1159,7 +1159,7 @@ class Iris:
 
             _all_to_all(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config)
 
-        def all_gather(self, output_tensor, input_tensor, group=None, async_op=False, config=None):
+        def all_gather(self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None):
             """
             All-gather collective operation.
 
@@ -1170,29 +1170,46 @@ class Iris:
             Args:
                 output_tensor: Output tensor of shape (world_size * M, N) - will contain concatenated inputs
                 input_tensor: Input tensor of shape (M, N) - local rank's data to send
-                group: ProcessGroup or None. If None, uses all ranks in shmem context.
+                group: ProcessGroup or None. If None, uses all ranks in iris context.
                        Default: None.
                 async_op: If False, performs a barrier at the end. If True, returns immediately.
                           Default: False.
                 config: Config instance with kernel parameters (default: None).
                         If None, uses default Config values.
+                workspace: Optional AllGatherWorkspace from ``all_gather_preamble``.
+                           Avoids per-call heap allocation for ring variant.
 
             Example:
                 >>> ctx = iris.iris()
                 >>> # Input: (M, N), Output: (world_size * M, N)
                 >>> ctx.ccl.all_gather(output_tensor, input_tensor)
 
-                >>> # Custom configuration
+                >>> # Ring variant with pre-allocated workspace
                 >>> from iris.ccl import Config
-                >>> config = Config(block_size_m=128, block_size_n=32)
-                >>> ctx.ccl.all_gather(output_tensor, input_tensor, config=config)
-
-                >>> # Async operation (no barrier)
-                >>> ctx.ccl.all_gather(output_tensor, input_tensor, async_op=True)
+                >>> config = Config(all_gather_variant="ring")
+                >>> ws = ctx.ccl.all_gather_preamble(out, inp, config=config)
+                >>> ctx.ccl.all_gather(out, inp, config=config, workspace=ws)
             """
             from iris.ccl.all_gather import all_gather as _all_gather
 
-            _all_gather(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config)
+            _all_gather(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config, workspace=workspace)
+
+        def all_gather_preamble(self, output_tensor, input_tensor, config=None, workspace=None):
+            """
+            Pre-allocate reusable workspace for ring-based all-gather.
+
+            Args:
+                output_tensor: Output tensor of shape (world_size * M, N).
+                input_tensor: Input tensor of shape (M, N).
+                config: Optional Config describing variant parameters.
+                workspace: Optional existing workspace to update/reuse.
+
+            Returns:
+                AllGatherWorkspace that can be passed to ``all_gather``.
+            """
+            from iris.ccl.all_gather import all_gather_preamble as _all_gather_preamble
+
+            return _all_gather_preamble(output_tensor, input_tensor, self._iris, config=config, workspace=workspace)
 
         def all_reduce_preamble(self, output_tensor, input_tensor, config=None, workspace=None):
             """

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -1159,7 +1159,9 @@ class Iris:
 
             _all_to_all(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config)
 
-        def all_gather(self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None, tracing=False):
+        def all_gather(
+            self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None, tracing=False
+        ):
             """
             All-gather collective operation.
 

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -1159,7 +1159,7 @@ class Iris:
 
             _all_to_all(output_tensor, input_tensor, self._iris, group=group, async_op=async_op, config=config)
 
-        def all_gather(self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None):
+        def all_gather(self, output_tensor, input_tensor, group=None, async_op=False, config=None, workspace=None, tracing=False):
             """
             All-gather collective operation.
 
@@ -1178,6 +1178,8 @@ class Iris:
                         If None, uses default Config values.
                 workspace: Optional AllGatherWorkspace from ``all_gather_preamble``.
                            Avoids per-call heap allocation for ring variant.
+                tracing: Enable iris tracing for remote operations (default: False).
+                         Zero overhead when disabled.
 
             Example:
                 >>> ctx = iris.iris()
@@ -1189,6 +1191,11 @@ class Iris:
                 >>> config = Config(all_gather_variant="ring")
                 >>> ws = ctx.ccl.all_gather_preamble(out, inp, config=config)
                 >>> ctx.ccl.all_gather(out, inp, config=config, workspace=ws)
+
+                >>> # With tracing enabled
+                >>> ctx.tracing.enable(max_events=1_000_000)
+                >>> ctx.ccl.all_gather(out, inp, config=config, tracing=True)
+                >>> ctx.tracing.export("ring_trace.json")
             """
             from iris.ccl.all_gather import all_gather as _all_gather
 
@@ -1200,6 +1207,7 @@ class Iris:
                 async_op=async_op,
                 config=config,
                 workspace=workspace,
+                tracing=tracing,
             )
 
         def all_gather_preamble(self, output_tensor, input_tensor, config=None, workspace=None):

--- a/tests/ccl/test_all_gather.py
+++ b/tests/ccl/test_all_gather.py
@@ -102,6 +102,70 @@ def test_all_gather(dtype, M, N, block_size_m, block_size_n):
     "M, N, block_size_m, block_size_n",
     [
         (128, 64, 32, 64),  # Small
+        (128, 128, 32, 32),  # Multi-block per rank
+        (1024, 256, 32, 64),  # Medium
+        (8192, 8192, 32, 64),  # Large
+    ],
+)
+def test_all_gather_ring(dtype, M, N, block_size_m, block_size_n):
+    """Test all-gather with ring variant by comparing against PyTorch's implementation."""
+    if not dist.is_initialized():
+        pytest.skip("torch.distributed not initialized")
+
+    heap_size = 2**33  # 8GB
+    shmem = iris.iris(heap_size)
+    rank = shmem.get_rank()
+    world_size = shmem.get_num_ranks()
+
+    # Reference: PyTorch all_gather_into_tensor
+    pytorch_input_tensor = torch.randn(M, N, dtype=dtype, device=f"cuda:{rank}")
+    pytorch_input_tensor.fill_(float(rank + 1))
+
+    pytorch_output_tensor = torch.zeros(world_size * M, N, dtype=dtype, device=f"cuda:{rank}")
+
+    shmem.barrier()
+    dist.all_gather_into_tensor(pytorch_output_tensor, pytorch_input_tensor)
+    torch.cuda.synchronize()
+
+    # Iris all_gather with ring variant
+    iris_input_tensor = shmem.zeros((M, N), dtype=dtype)
+    iris_input_tensor.copy_(pytorch_input_tensor)
+
+    iris_output_tensor = shmem.zeros((world_size * M, N), dtype=dtype)
+
+    shmem.barrier()
+    config = Config(block_size_m=block_size_m, block_size_n=block_size_n, all_gather_variant="ring")
+    shmem.ccl.all_gather(iris_output_tensor, iris_input_tensor, config=config)
+    torch.cuda.synchronize()
+
+    atol = 1e-3 if dtype == torch.float16 else 1e-5
+    max_diff = torch.abs(iris_output_tensor - pytorch_output_tensor).max().item()
+
+    try:
+        assert torch.allclose(iris_output_tensor, pytorch_output_tensor, atol=atol), (
+            f"Max difference: {max_diff}, expected < {atol}\n"
+            f"Rank {rank}: Iris output (ring) doesn't match PyTorch's all_gather_into_tensor"
+        )
+    finally:
+        shmem.barrier()
+        del shmem
+        import gc
+
+        gc.collect()
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float16,
+        torch.float32,
+        torch.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "M, N, block_size_m, block_size_n",
+    [
+        (128, 64, 32, 64),  # Small
         (128, 128, 32, 32),  # BLOCK_N < N/world_size (partial-width, multi-block per rank)
         (256, 128, 32, 16),  # Minimum BLOCK_N=16 (16-bit vectorization path)
         (1024, 256, 32, 64),  # Medium

--- a/tests/ccl/test_all_gather.py
+++ b/tests/ccl/test_all_gather.py
@@ -113,9 +113,9 @@ def test_all_gather_ring(dtype, M, N, block_size_m, block_size_n):
         pytest.skip("torch.distributed not initialized")
 
     heap_size = 2**33  # 8GB
-    shmem = iris.iris(heap_size)
-    rank = shmem.get_rank()
-    world_size = shmem.get_num_ranks()
+    ctx = iris.iris(heap_size)
+    rank = ctx.get_rank()
+    world_size = ctx.get_num_ranks()
 
     # Reference: PyTorch all_gather_into_tensor
     pytorch_input_tensor = torch.randn(M, N, dtype=dtype, device=f"cuda:{rank}")
@@ -123,19 +123,19 @@ def test_all_gather_ring(dtype, M, N, block_size_m, block_size_n):
 
     pytorch_output_tensor = torch.zeros(world_size * M, N, dtype=dtype, device=f"cuda:{rank}")
 
-    shmem.barrier()
+    ctx.barrier()
     dist.all_gather_into_tensor(pytorch_output_tensor, pytorch_input_tensor)
     torch.cuda.synchronize()
 
     # Iris all_gather with ring variant
-    iris_input_tensor = shmem.zeros((M, N), dtype=dtype)
+    iris_input_tensor = ctx.zeros((M, N), dtype=dtype)
     iris_input_tensor.copy_(pytorch_input_tensor)
 
-    iris_output_tensor = shmem.zeros((world_size * M, N), dtype=dtype)
+    iris_output_tensor = ctx.zeros((world_size * M, N), dtype=dtype)
 
-    shmem.barrier()
+    ctx.barrier()
     config = Config(block_size_m=block_size_m, block_size_n=block_size_n, all_gather_variant="ring")
-    shmem.ccl.all_gather(iris_output_tensor, iris_input_tensor, config=config)
+    ctx.ccl.all_gather(iris_output_tensor, iris_input_tensor, config=config)
     torch.cuda.synchronize()
 
     atol = 1e-3 if dtype == torch.float16 else 1e-5
@@ -147,8 +147,8 @@ def test_all_gather_ring(dtype, M, N, block_size_m, block_size_n):
             f"Rank {rank}: Iris output (ring) doesn't match PyTorch's all_gather_into_tensor"
         )
     finally:
-        shmem.barrier()
-        del shmem
+        ctx.barrier()
+        del ctx
         import gc
 
         gc.collect()


### PR DESCRIPTION
## Summary
- Add ring-based `all_gather` variant using flag-based producer/consumer sync
- Each rank forwards data around a ring (O(1) writes per step vs O(N) for persistent)
- Add `AllGatherWorkspace` + `all_gather_preamble()` for pre-allocated scratch buffers
- Fix Triton negative modulo bug (`%` uses C truncated-division, not Python floored)
- Rename `shmem` → `ctx` in all_gather module and ring tests

## Test plan
- [x] All 42 existing all_gather tests pass on 8x MI355X (persistent + partitioned + ring)
- [x] New `test_all_gather_ring` covers 4 shapes × 3 dtypes = 12 test cases
- [x] Manual correctness test with 2, 4, and 8 ranks
- [x] Performance study: [gist](https://gist.github.com/mawad-amd/97c82dbc2c0ec8655b6df09111e257ec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)