### PR TITLE
bench: report cross-rank timing stats

### DIFF
--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -432,8 +432,9 @@ def _run_benchmarks_worker(
 
                 # Cross-rank: gather every rank's median to compute
                 # max (true collective latency), min, and skew.
-                local_t = torch.tensor([local_median_ms], device="cuda")
-                gathered = [torch.zeros(1, device="cuda") for _ in range(world_size)]
+                gather_device = "cuda" if backend == "nccl" else "cpu"
+                local_t = torch.tensor([local_median_ms], device=gather_device)
+                gathered = [torch.zeros(1, device=gather_device) for _ in range(world_size)]
                 dist.all_gather(gathered, local_t)
                 rank_medians = [t.item() for t in gathered]
 

--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -456,7 +456,7 @@ def _run_benchmarks_worker(
 
                 counters = dict(state._counters)
                 counters["min_ms"] = min_ms
-                counters["skew_%"] = skew_pct
+                counters["skew_pct"] = skew_pct
 
                 all_results.append(
                     Result(

--- a/iris/bench/_runner.py
+++ b/iris/bench/_runner.py
@@ -427,25 +427,45 @@ def _run_benchmarks_worker(
                     return_mode="all",
                 )
 
-                mean_ms = statistics.mean(times)
+                # Per-rank: median across iterations (robust to outliers)
+                local_median_ms = statistics.median(times)
+
+                # Cross-rank: gather every rank's median to compute
+                # max (true collective latency), min, and skew.
+                local_t = torch.tensor([local_median_ms], device="cuda")
+                gathered = [torch.zeros(1, device="cuda") for _ in range(world_size)]
+                dist.all_gather(gathered, local_t)
+                rank_medians = [t.item() for t in gathered]
+
+                max_ms = max(rank_medians)
+                min_ms = min(rank_medians)
+                skew_pct = ((max_ms - min_ms) / max_ms * 100) if max_ms > 0 else 0.0
+
+                # Headline time = max across ranks (slowest rank
+                # determines when the collective is actually done).
+                gpu_time_ms = max_ms
 
                 bw = None
-                if state._bytes is not None and mean_ms > 0:
-                    bw = (state._bytes / 1e9) / (mean_ms * 1e-3)
+                if state._bytes is not None and gpu_time_ms > 0:
+                    bw = (state._bytes / 1e9) / (gpu_time_ms * 1e-3)
 
                 tflops = None
-                if state._flops is not None and mean_ms > 0:
-                    tflops = (state._flops / 1e12) / (mean_ms * 1e-3)
+                if state._flops is not None and gpu_time_ms > 0:
+                    tflops = (state._flops / 1e12) / (gpu_time_ms * 1e-3)
+
+                counters = dict(state._counters)
+                counters["min_ms"] = min_ms
+                counters["skew_%"] = skew_pct
 
                 all_results.append(
                     Result(
                         benchmark_name=bdef.name,
                         params=params,
-                        gpu_time_ms=mean_ms,
+                        gpu_time_ms=gpu_time_ms,
                         all_times_ms=times,
                         bandwidth_gbps=bw,
                         tflops=tflops,
-                        counters=dict(state._counters),
+                        counters=counters,
                         world_size=world_size,
                     )
                 )


### PR DESCRIPTION
## Summary
- Report timing from **all ranks** instead of only rank 0. Each rank computes the median of its iteration times, then `dist.all_gather` collects every rank's median to rank 0.
- Headline `GPU Time` is now **max across ranks** (the true collective latency — slowest rank determines when the operation is done).
- Two new counter columns: `min_ms` (fastest rank) and `skew_%` (`(max - min) / max * 100`, straggler penalty as a percentage).
- Supports both NCCL (CUDA tensors) and gloo (CPU tensors) backends for the gather.

Example output on MI308X ×8:
```
num_ranks     M     N     dtype   variant  GPU Time (ms)  BW (GB/s)  min_ms  skew_%
        8  1024  1024  bfloat16  two_shot          0.217       16.9   0.215   0.953
        8  4096  1024  bfloat16  two_shot          0.272       53.9   0.270   0.758
```

## Test plan
- [x] Ran `bench_all_reduce.py` on MI308X ×8 with `--axis_num_ranks=8 --axis_M=1024,4096 --axis_N=1024 --axis_dtype=bf16`
- [ ] Verify JSON and CSV output formats include new counters
- [ ] Test with `--axis_num_ranks=2,4,8` to confirm multi-launch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)