### PR TITLE
Fix GPU reset workflow runner label

### DIFF
--- a/.github/workflows/gpu-reset.yml
+++ b/.github/workflows/gpu-reset.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   reset:
-    runs-on: [self-hosted, amdgpu]
+    runs-on: [self-hosted, mi3xx]
     steps:
       - name: Reset GPU bitmap
         run: |


### PR DESCRIPTION
amdgpu label doesn't exist on any runner. Changed to mi3xx.

[skip ci]