### PR TITLE
Add a docker file with a dev script to use the latest rocm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ rocSHMEM/
 *.sif.checksum
 apptainer/images/
 .vscode/
+.idea/
 __pycache__/
 *.so
 *.json
@@ -58,3 +59,6 @@ logs/
 *.cap
 hsakmt_counters.csv
 core
+
+docker/TheRock/
+docker/rocm-systems/

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Dockerfile.dev
+#
+# Builds the entire ROCm stack from source using TheRock, which includes
+# rocm-systems as a submodule. Optionally replaces rocm-systems with a
+# custom fork (staged by build-dev.sh as TheRock/custom-rocm-systems).
+#
+# Build via build-dev.sh (recommended):
+#   ./build-dev.sh
+#   ./build-dev.sh -g gfx942
+#   ./build-dev.sh -r git@github.com:ROCm/rocm-systems.git
+#
+# Build args:
+#   AMDGPU_FAMILIES    - GPU architecture family (default: gfx110X-all)
+#   SWAP_ROCM_SYSTEMS  - Set to "true" to swap rocm-systems (default: false)
+#   BUILD_JOBS         - Parallel build jobs (default: nproc)
+
+# Base Ubuntu with build dependencies
+FROM ubuntu:24.04 AS base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    wget \
+    gnupg2 \
+    git \
+    git-lfs \
+    build-essential \
+    cmake \
+    ninja-build \
+    pkg-config \
+    python3 \
+    python3-pip \
+    python3-dev \
+    python3-venv \
+    python3-setuptools \
+    libdrm-dev \
+    libelf-dev \
+    libnuma-dev \
+    libpci-dev \
+    libncurses-dev \
+    libsystemd-dev \
+    libcap-dev \
+    libudev-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    libgrpc++-dev \
+    protobuf-compiler-grpc \
+    libsqlite3-dev \
+    libfmt-dev \
+    libaio-dev \
+    libgtest-dev \
+    libegl1-mesa-dev \
+    libdwarf-dev \
+    xxd \
+    patchelf \
+    automake \
+    libtool \
+    texinfo \
+    bison \
+    flex \
+    gfortran \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r video 2>/dev/null || true && \
+    groupadd -r render 2>/dev/null || true
+
+# Build TheRock (full ROCm stack including rocm-systems)
+
+FROM base AS builder
+
+ARG AMDGPU_FAMILIES="gfx110X-all"
+ARG SWAP_ROCM_SYSTEMS="false"
+ARG BUILD_JOBS=""
+
+COPY TheRock /opt/TheRock-src
+WORKDIR /opt/TheRock-src
+
+RUN git config --global --add safe.directory '*'
+
+# Set up Python venv and install TheRock dependencies
+RUN python3 -m venv /opt/therock-venv && \
+    source /opt/therock-venv/bin/activate && \
+    pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+# Fetch submodules and apply patches
+RUN source /opt/therock-venv/bin/activate && \
+    python3 ./build_tools/fetch_sources.py
+
+# Swap rocm-systems with custom version AFTER fetch_sources.py
+# so it doesn't get overwritten by submodule checkout
+RUN if [[ "$SWAP_ROCM_SYSTEMS" == "true" && -d /opt/TheRock-src/custom-rocm-systems ]]; then \
+        echo "===> Swapping rocm-systems with custom version" && \
+        rm -rf /opt/TheRock-src/rocm-systems && \
+        mv /opt/TheRock-src/custom-rocm-systems /opt/TheRock-src/rocm-systems; \
+    else \
+        echo "===> Using TheRock default rocm-systems"; \
+    fi
+
+# Configure
+RUN source /opt/therock-venv/bin/activate && \
+    cmake -B build -G Ninja . \
+    -DTHEROCK_AMDGPU_FAMILIES="${AMDGPU_FAMILIES}" \
+    -DBUILD_TESTING=OFF
+
+# Build (longest step - compiles LLVM, HIP, rocm-systems projects, etc.)
+RUN source /opt/therock-venv/bin/activate && \
+    cmake --build build --parallel ${BUILD_JOBS:-$(nproc)}
+
+# Install to /opt/rocm
+RUN mkdir -p /opt/rocm && \
+    cp -a build/dist/rocm/* /opt/rocm/
+
+# Final development image
+
+FROM base AS final
+
+COPY --from=builder /opt/rocm /opt/rocm
+
+ENV TRITON_PATH=/opt/triton \
+    ROCM_PATH=/opt/rocm \
+    OMPI_MCA_mtl="^ofi" \
+    OMPI_MCA_pml="ob1" \
+    HSA_NO_SCRATCH_RECLAIM=1
+
+ENV LD_LIBRARY_PATH=$ROCM_PATH/lib \
+    PATH="$ROCM_PATH/bin:$PATH"
+
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+    OMPI_ALLOW_RUN_AS_ROOT=1
+
+# Set up Python venv (matches original rocm/pytorch base image pattern)
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Make the venv writable by all
+RUN chmod -R 777 /opt/venv
+
+# Install Python packages with pip
+RUN pip3 install --upgrade pip && \
+    pip3 install wheel jupyter
+
+# Install PyTorch (ROCm-compatible wheel)
+RUN pip3 install \
+    torch torchvision torchaudio \
+    --index-url https://download.pytorch.org/whl/rocm7.2
+
+# Clone and install Triton
+WORKDIR $TRITON_PATH
+RUN git clone https://github.com/triton-lang/triton.git $TRITON_PATH && \
+    git checkout bcbcabdd0cff6539c7168299075992b2a23ff38e && \
+    pip3 install -e .
+ENV PYTHONPATH=$TRITON_PATH
+
+# Set up workspace
+WORKDIR /workspace
+
+# Create entrypoint script
+RUN echo '#!/bin/bash' > /entrypoint.sh && \
+    echo 'git config --global --add safe.directory "*" 2>/dev/null' >> /entrypoint.sh && \
+    echo 'echo "Welcome to the ROCm-from-source Docker image!"' >> /entrypoint.sh && \
+    echo 'echo "Built from TheRock (includes rocm-systems)"' >> /entrypoint.sh && \
+    echo 'echo "ROCm path: $ROCM_PATH"' >> /entrypoint.sh && \
+    echo 'if command -v rocminfo &>/dev/null; then' >> /entrypoint.sh && \
+    echo '    echo "rocminfo available: $(which rocminfo)"' >> /entrypoint.sh && \
+    echo 'fi' >> /entrypoint.sh && \
+    echo 'if [ $# -eq 0 ]; then' >> /entrypoint.sh && \
+    echo '    exec /bin/bash' >> /entrypoint.sh && \
+    echo 'else' >> /entrypoint.sh && \
+    echo '    exec "$@"' >> /entrypoint.sh && \
+    echo 'fi' >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "-c", "source /entrypoint.sh && exec bash"]

--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Builds the iris-dev-custom Docker image from source using TheRock.
+# Always uses Dockerfile.dev.
+#
+# If TheRock/ or rocm-systems/ directories already exist in the current
+# folder, they are reused. Otherwise they are cloned from the given URLs.
+#
+# Usage:
+#   ./build-dev.sh [OPTIONS]
+#
+# Options:
+#   -n, --name IMAGE_NAME         Docker image name (default: iris-dev-custom)
+#   -g, --gpu-family FAMILY       THEROCK_AMDGPU_FAMILIES value (default: gfx110X-all)
+#   -t, --therock-repo URL        TheRock git repo URL
+#                                 (default: https://github.com/ROCm/TheRock.git)
+#   -r, --rocm-systems-repo URL   Custom rocm-systems git repo URL
+#                                 (replaces TheRock's built-in rocm-systems)
+#   -h, --help                    Show this help message
+#
+# Examples:
+#   # Default: uses existing dirs or clones, gfx110X-all
+#   ./build-dev.sh
+#
+#   # Custom GPU family
+#   ./build-dev.sh -g gfx942
+#
+#   # Custom rocm-systems repo (clones if rocm-systems/ doesn't exist)
+#   ./build-dev.sh -r git@github.com:ROCm/rocm-systems.git
+#
+#   # Everything custom
+#   ./build-dev.sh -g gfx942 \
+#       -t git@github.com:ROCm/TheRock.git \
+#       -r git@github.com:ROCm/rocm-systems.git
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+DOCKERFILE="Dockerfile.dev"
+
+# Defaults
+IMAGE_NAME="iris-dev-custom"
+AMDGPU_FAMILIES="gfx110X-all"
+THEROCK_REPO="git@github.com:ROCm/TheRock.git"
+ROCM_SYSTEMS_REPO=""
+SWAP_ROCM_SYSTEMS="false"
+
+usage() {
+    sed -n '2,/^$/s/^#//p' "$0"
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--name)
+            IMAGE_NAME="$2"
+            shift 2
+            ;;
+        -g|--gpu-family)
+            AMDGPU_FAMILIES="$2"
+            shift 2
+            ;;
+        -t|--therock-repo)
+            THEROCK_REPO="$2"
+            shift 2
+            ;;
+        -r|--rocm-systems-repo)
+            ROCM_SYSTEMS_REPO="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+pushd "$SCRIPT_DIR" > /dev/null
+
+if [[ ! -f "$DOCKERFILE" ]]; then
+    echo "Error: $DOCKERFILE not found in $SCRIPT_DIR"
+    exit 1
+fi
+
+# --- TheRock ---
+if [[ -d "TheRock" ]]; then
+    echo "==> Using existing TheRock directory."
+else
+    echo "==> Cloning TheRock from: $THEROCK_REPO"
+    git clone "$THEROCK_REPO" TheRock
+fi
+
+# --- Custom rocm-systems ---
+# If -r is passed, clone from that URL (unless rocm-systems/ already exists)
+# If -r is not passed but rocm-systems/ exists locally, use it
+# The custom rocm-systems is staged as TheRock/custom-rocm-systems and
+# swapped inside the Dockerfile AFTER fetch_sources.py
+if [[ -n "$ROCM_SYSTEMS_REPO" ]]; then
+    if [[ -d "rocm-systems" ]]; then
+        echo "==> Using existing rocm-systems directory."
+    else
+        echo "==> Cloning custom rocm-systems from: $ROCM_SYSTEMS_REPO"
+        git clone --recursive "$ROCM_SYSTEMS_REPO" rocm-systems
+    fi
+    echo "==> Staging custom rocm-systems into TheRock/custom-rocm-systems"
+    rm -rf TheRock/custom-rocm-systems
+    cp -a rocm-systems TheRock/custom-rocm-systems
+    SWAP_ROCM_SYSTEMS="true"
+elif [[ -d "rocm-systems" ]]; then
+    echo "==> Found existing rocm-systems directory, using it."
+    echo "==> Staging custom rocm-systems into TheRock/custom-rocm-systems"
+    rm -rf TheRock/custom-rocm-systems
+    cp -a rocm-systems TheRock/custom-rocm-systems
+    SWAP_ROCM_SYSTEMS="true"
+else
+    echo "==> No custom rocm-systems, using TheRock default."
+fi
+
+echo ""
+echo "========================================="
+echo "  Building Docker image"
+echo "========================================="
+echo "  Image name:      $IMAGE_NAME"
+echo "  Dockerfile:      $DOCKERFILE"
+echo "  GPU family:      $AMDGPU_FAMILIES"
+echo "  TheRock:         $THEROCK_REPO"
+if [[ "$SWAP_ROCM_SYSTEMS" == "true" ]]; then
+    echo "  rocm-systems:    custom (from ./rocm-systems)"
+else
+    echo "  rocm-systems:    (TheRock default)"
+fi
+echo "========================================="
+echo ""
+
+docker build -t "$IMAGE_NAME" -f "$DOCKERFILE" \
+    --build-arg AMDGPU_FAMILIES="$AMDGPU_FAMILIES" \
+    --build-arg SWAP_ROCM_SYSTEMS="$SWAP_ROCM_SYSTEMS" \
+    .
+
+popd > /dev/null


### PR DESCRIPTION
## Motivation

Adds Dockerfile.dev and build-dev.sh to build the entire ROCm stack from source using [TheRock](https://github.com/ROCm/TheRock), with optional support for substituting a custom rocm-systems fork. This enables development and testing against the latest ROCm components without depending on prebuilt ROCm packages.

Examples:

* Default: uses existing dirs or clones from the TheRock repository with rocm-systems, and GPU family gfx110X-all
``` 
./build-dev.sh 
```

* Custom GPU family
```  
./build-dev.sh -g gfx942 
```

* Custom rocm-systems repo (clones if rocm-systems/ doesn't exist)
```   
./build-dev.sh -r git@github.com:ROCm/rocm-systems.git 
```

* Everything custom
```  
./build-dev.sh -g gfx942 \
       -t git@github.com:ROCm/TheRock.git \
       -r git@github.com:ROCm/rocm-systems.git
```

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
