### PR TITLE
Update tritonblas dep to skip origami C++ build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy",
     "requests",
     "ruff",
-    "tritonblas @ git+https://github.com/ROCm/tritonBLAS.git@df58476a4520b72495a3f03f911368a184126568",
+    "tritonblas @ git+https://github.com/ROCm/tritonBLAS.git@muhaawad/iris",
 
 ]
 


### PR DESCRIPTION
## Summary
- Updates the tritonblas dependency from a pinned commit on `main` to the `muhaawad/iris` branch of [ROCm/tritonBLAS](https://github.com/ROCm/tritonBLAS/tree/muhaawad/iris)
- The `muhaawad/iris` branch makes the origami C++ extension optional — `setup.py` skips the hipcc build entirely, and `__init__.py` wraps origami imports in try/except
- iris only uses `tritonblas.kernels.stages` (pure Python Triton JIT code), so the origami C++ library is not needed
- This removes the need for the `--no-deps` flag or tritonblas stubs when installing iris

## Changes on `ROCm/tritonBLAS@muhaawad/iris`
- `setup.py`: removed `CustomBuildExt` and `ext_modules` (no hipcc clone/build)
- `__init__.py`: `try/except ImportError` around matmul/origami imports

## Test plan
- [ ] `pip install git+https://github.com/ROCm/iris.git@muhaawad/tritonblas-dep` succeeds without hipcc
- [ ] `from tritonblas.kernels.stages import GemmContext, ScheduleContext, Tile` works
- [ ] iris matmul ops (`all_gather_matmul`, `matmul_reduce_scatter`, etc.) import correctly
- [ ] Existing CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)