### PR TITLE
fix: install libdwarf-dev for Copilot Setup Steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,6 +30,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e . --no-cache-dir
 
+      - name: Install build dependencies for IntelliKit
+        run: |
+          apt-get update -qq && apt-get install -y -qq libdwarf-dev libelf-dev > /dev/null
+
       - name: Install IntelliKit Python packages
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"
@@ -59,7 +63,8 @@ jobs:
       - name: Make venv default for subsequent steps
         run: |
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
-          echo "PYTHONPATH=$GITHUB_WORKSPACE/.venv/lib/python3.13/site-packages:$GITHUB_WORKSPACE${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/.venv/lib/python${PYVER}/site-packages:$GITHUB_WORKSPACE${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
 
       - name: Verify ROCm and GPU visibility
         run: |


### PR DESCRIPTION
## Summary
- Install `libdwarf-dev` and `libelf-dev` before IntelliKit packages — KernelDB's cmake build requires libdwarf headers (`CMakeLists.txt:142`)
- Fix hardcoded `python3.13` in PYTHONPATH — the `muhaawad/iris-dev` image has Python 3.12, now auto-detected

## Root cause
`accordo` depends on `kerneldb`, which has a native cmake extension. The cmake configure step fails with:
```
CMake Error at CMakeLists.txt:142 (message):
  libdwarf headers not found.
```

## Test plan
- [ ] Trigger Copilot Setup Steps workflow manually and verify it passes
- [ ] Verify Copilot can respond to `@copilot` comments on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)