### PR TITLE
Add libdwarf-dev to nightly Docker image and derive PYTHONPATH dynamically

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Make venv default for subsequent steps
         run: |
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
-          echo "PYTHONPATH=$GITHUB_WORKSPACE/.venv/lib/python3.13/site-packages:$GITHUB_WORKSPACE${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
+          VENV_SITE_PACKAGES="$("$GITHUB_WORKSPACE/.venv/bin/python" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"
+          echo "PYTHONPATH=$VENV_SITE_PACKAGES:$GITHUB_WORKSPACE${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
 
       - name: Verify ROCm and GPU visibility
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,10 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e . --no-cache-dir
 
-      - name: Install build dependencies for IntelliKit
-        run: |
-          apt-get update -qq && apt-get install -y -qq libdwarf-dev libelf-dev > /dev/null
-
       - name: Install IntelliKit Python packages
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"
@@ -63,8 +59,7 @@ jobs:
       - name: Make venv default for subsequent steps
         run: |
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-          echo "PYTHONPATH=$GITHUB_WORKSPACE/.venv/lib/python${PYVER}/site-packages:$GITHUB_WORKSPACE${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/.venv/lib/python3.13/site-packages:$GITHUB_WORKSPACE${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
 
       - name: Verify ROCm and GPU visibility
         run: |

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -90,7 +90,7 @@ jobs:
 
           RUN apt-get update && \
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                  git build-essential cmake ninja-build && \
+                  git build-essential cmake ninja-build libdwarf-dev libelf-dev && \
               rm -rf /var/lib/apt/lists/*
 
           # Remove base image triton, install from source at pinned commit


### PR DESCRIPTION
## Summary
- Add `libdwarf-dev` and `libelf-dev` to the nightly Docker image (`docker-nightly.yml`) — KernelDB cmake requires libdwarf headers
- Remove failing `apt-get install` step from `copilot-setup-steps.yml` — Apptainer SIF is read-only (`/var/lib/apt/lists/partial: Read-only file system`)

## Root cause
`accordo` (IntelliKit) depends on `kerneldb`, which has a native cmake extension requiring `libdwarf.h`. The nightly Docker image (`rocm/pytorch` base) doesn't include this header. Since the copilot runner executes inside a read-only Apptainer SIF, we can't `apt-get install` at runtime — the fix must go into the image itself.

## Test plan
- [ ] Trigger Nightly Docker Build to rebuild image with libdwarf-dev
- [ ] Re-trigger Copilot Setup Steps workflow after new image is pulled
- [ ] Verify KernelDB wheel builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)