### PR TITLE
Install libdwarf-dev in Copilot Setup Steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,6 +30,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e . --no-cache-dir
 
+      - name: Install native build dependencies
+        run: |
+          apt-get update -qq && apt-get install -y -qq libdwarf-dev libelf-dev > /dev/null
+
       - name: Install IntelliKit Python packages
         run: |
           source "$GITHUB_WORKSPACE/.venv/bin/activate"


### PR DESCRIPTION
## Summary
- Install libdwarf-dev and libelf-dev before IntelliKit packages
- Container now runs with --writable-tmpfs so apt-get works
- KernelDB (dependency of accordo) needs libdwarf headers to build its native extension

## Test plan
- [ ] Trigger Copilot Setup Steps workflow and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)