### PR TITLE
Add SP benchmarks for GPT-OSS-120B MoE model (GEMM+RS, RS+RMSNorm, E2E)

### DIFF
--- a/benchmark/ops/bench_matmul_reduce_scatter_stages.py
+++ b/benchmark/ops/bench_matmul_reduce_scatter_stages.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Stage profiler for fused GEMM + Reduce-Scatter.
+
+Models the O_proj (row-parallel GEMM) + Reduce-Scatter for GPT-OSS-120B in
+Sequence Parallelism mode.  GPT-OSS-120B is an MoE model (128 experts, top-4)
+whose MoE layer handles its own sequence parallelism internally, so there is
+no All-Gather after RMSNorm and no column-parallel FFN GEMM.
+
+SP dataflow (GPT-OSS-120B):
+  O_proj: [M, K_local] x [K_local, N] → partial [M, N]
+    → Reduce-Scatter → [M/tp, N]
+    → RMSNorm on [M/tp, N]
+    → (MoE receives [M/tp, N] directly — handles its own AG at exit)
+
+  K = num_heads * head_dim = 64 * 64 = 4096
+  N = hidden_size = 2880
+
+Sweeps optimization stages (atomic → two_shot → one_shot) across
+vLLM-shaped workloads (decode / hybrid / prefill) and compares
+against the unfused baseline (torch.mm + dist.reduce_scatter_tensor).
+"""
+
+import torch
+import torch.distributed as dist
+import iris.bench as bench
+from iris.ops import FusedConfig, matmul_reduce_scatter, matmul_reduce_scatter_preamble
+
+
+# --- Unfused baseline: torch.mm + RCCL reduce_scatter_tensor ---
+
+
+@bench.register
+@bench.axis("num_ranks", [2, 4, 8])
+@bench.axis("M", [32, 896, 2048])
+@bench.axis("N", [2880])
+@bench.axis("K", [4096])
+@bench.axis("dtype", [torch.float16])
+def unfused_mm_reduce_scatter(state, ctx):
+    M, N, K_global = state["M"], state["N"], state["K"]
+    dtype = state["dtype"]
+    num_ranks = ctx.get_num_ranks()
+    K_local = K_global // num_ranks
+    M_local = M // num_ranks  # sequence shard each rank owns after RS
+
+    A = torch.randn((M, K_local), device="cuda", dtype=dtype)
+    B = torch.randn((K_local, N), device="cuda", dtype=dtype)
+    C_full = torch.empty((M, N), device="cuda", dtype=dtype)
+    C_local = torch.empty((M_local, N), device="cuda", dtype=dtype)
+
+    state.set_flops(2 * M * N * K_local)
+    state.set_bytes((num_ranks - 1) * M_local * N * A.element_size())
+
+    def _run():
+        torch.mm(A, B, out=C_full)
+        dist.reduce_scatter_tensor(C_local, C_full, op=dist.ReduceOp.SUM)
+
+    state.exec(_run)
+
+
+# --- Fused GEMM+RS: sweep variant × tile config ---
+
+
+@bench.register
+@bench.axis("num_ranks", [2, 4, 8])
+@bench.axis("M", [32, 896, 2048])
+@bench.axis("N", [2880])
+@bench.axis("K", [4096])
+@bench.axis("dtype", [torch.float16])
+@bench.axis("bm", [32, 64, 128])
+@bench.axis("bn", [64, 128])
+def fused_gemm_reduce_scatter(state, ctx):
+    M, N, K_global = state["M"], state["N"], state["K"]
+    dtype = state["dtype"]
+    bm, bn = state["bm"], state["bn"]
+    num_ranks = ctx.get_num_ranks()
+    K_local = K_global // num_ranks
+    M_local = M // num_ranks
+
+    # Skip configs where block > problem size
+    if bm > M:
+        state.skip(f"bm={bm} > M={M}")
+        return
+    if bn > N:
+        state.skip(f"bn={bn} > N={N}")
+        return
+
+    A = ctx.zeros((M, K_local), dtype=dtype)
+    A.fill_(float(ctx.get_rank() + 1) * 0.01)
+    B = torch.randn((K_local, N), device="cuda", dtype=dtype)
+    C = ctx.zeros((M_local, N), dtype=dtype)  # RS output: each rank owns M_local rows
+
+    config = FusedConfig(
+        block_size_m=bm,
+        block_size_n=bn,
+        block_size_k=64,
+        group_size_m=4,
+        num_xcds=8,
+        all_reduce_variant="two_shot",  # RS kernel only implements two_shot
+    )
+    workspace = matmul_reduce_scatter_preamble(ctx, C, A, B, config=config)
+
+    state.set_flops(2 * M * N * K_local)
+    state.set_bytes((num_ranks - 1) * M_local * N * A.element_size())
+
+    def _run():
+        workspace.prepared = False
+        matmul_reduce_scatter(ctx, C, A, B, config=config, workspace=workspace)
+
+    def _preamble():
+        C.zero_()
+        if workspace.locks is not None:
+            workspace.locks.zero_()
+        if workspace.aux_buffer is not None:
+            workspace.aux_buffer.zero_()
+        workspace.prepared = True
+
+    state.exec(_run, preamble_fn=_preamble)
+
+
+if __name__ == "__main__":
+    bench.main()

--- a/benchmark/ops/bench_rs_rmsnorm.py
+++ b/benchmark/ops/bench_rs_rmsnorm.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Stage profiler for the SP middle section: Reduce-Scatter + RMSNorm.
+
+Models the section between O_proj output and MoE input for GPT-OSS-120B in
+Sequence Parallelism mode.  GPT-OSS-120B is an MoE model (128 experts, top-4)
+whose MoE layer handles its own sequence parallelism internally
+(sequence_parallel_chunk at entry + tensor_model_parallel_all_gather at exit),
+so there is no All-Gather after RMSNorm.
+
+    O_proj output [M, N]  (partial sums, one per rank)
+      -> Reduce-Scatter       each rank receives M_local = M/tp contiguous rows
+      -> RMSNorm              normalize the M_local-row shard
+      -> (MoE receives [M_local, N] directly — handles its own AG at exit)
+
+  K = num_heads * head_dim = 64 * 64 = 4096
+  N = hidden_size = 2880
+
+Two benchmarks:
+
+  unfused_rs_rmsnorm
+      dist.reduce_scatter_tensor  (NCCL)
+      + aiter triton rms_norm
+
+  fused_ready_rs_rmsnorm
+      Same ops but allocated with iris shared memory so the buffer is ready
+      for the eventual aiter fused kernel swap-in.
+
+Shapes match the O_proj benchmarks (N=2880 hidden dim, M=32/896/2048).
+"""
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import iris.bench as bench
+
+# Use aiter's Triton RMSNorm if available; fall back to torch
+try:
+    from aiter.ops.triton.rmsnorm import rms_norm as _aiter_rms_norm
+    def rmsnorm(x, weight, eps=1e-6):
+        return _aiter_rms_norm(x, weight, eps)
+    _RMSNORM_BACKEND = "aiter-triton"
+except Exception:
+    def rmsnorm(x, weight, eps=1e-6):
+        return F.rms_norm(x, [x.shape[-1]], weight=weight, eps=eps)
+    _RMSNORM_BACKEND = "torch"
+
+
+# ---------------------------------------------------------------------------
+# Unfused: NCCL RS  +  RMSNorm
+# Covers all M values (32 / 896 / 2048) and all TP degrees.
+# ---------------------------------------------------------------------------
+
+
+@bench.register
+@bench.axis("num_ranks", [2, 4, 8])
+@bench.axis("M", [32, 896, 2048])
+@bench.axis("N", [2880])
+@bench.axis("dtype", [torch.float16])
+def unfused_rs_rmsnorm(state, ctx):
+    M, N = state["M"], state["N"]
+    dtype = state["dtype"]
+    num_ranks = ctx.get_num_ranks()
+
+    if M % num_ranks != 0:
+        state.skip(f"M={M} not divisible by num_ranks={num_ranks}")
+        return
+
+    M_local = M // num_ranks
+
+    # Input: full [M, N] partial-sum tensor (output of O_proj GEMM on each rank)
+    inp = torch.randn((M, N), device="cuda", dtype=dtype)
+    # RS output: contiguous [M_local, N] shard
+    rs_out = torch.empty((M_local, N), device="cuda", dtype=dtype)
+    # RMSNorm weight
+    gamma = torch.ones(N, device="cuda", dtype=dtype)
+
+    # RS comm volume: each rank sends (num_ranks-1) shards of size M_local * N
+    state.set_bytes((num_ranks - 1) * M_local * N * inp.element_size())
+
+    def _run():
+        # 1. Reduce-Scatter: sum partial outputs, each rank gets M_local rows
+        dist.reduce_scatter_tensor(rs_out, inp, op=dist.ReduceOp.SUM)
+        # 2. RMSNorm on the M_local-row shard
+        rmsnorm(rs_out, gamma)
+
+    state.exec(_run)
+
+
+# ---------------------------------------------------------------------------
+# "Fused-ready" variant: same ops but input lives in iris shared memory.
+# This buffer layout is compatible with the aiter fused kernel calling convention.
+# Once the aiter comms module is released, replace the two-op _run body with
+# a single kernel call.
+# ---------------------------------------------------------------------------
+
+
+@bench.register
+@bench.axis("num_ranks", [2, 4, 8])
+@bench.axis("M", [32, 896, 2048])
+@bench.axis("N", [2880])
+@bench.axis("dtype", [torch.float16])
+def fused_ready_rs_rmsnorm(state, ctx):
+    """
+    Like unfused_rs_rmsnorm but all tensors allocated in iris shared memory,
+    matching the calling convention of aiter's fused kernel.
+
+    Swapping in the fused kernel is a one-line change once aiter.comms is
+    available in the installed package.
+    """
+    M, N = state["M"], state["N"]
+    dtype = state["dtype"]
+    num_ranks = ctx.get_num_ranks()
+
+    if M % num_ranks != 0:
+        state.skip(f"M={M} not divisible by num_ranks={num_ranks}")
+        return
+
+    M_local = M // num_ranks
+
+    # Allocate in iris shmem (required by the fused aiter kernel)
+    inp = ctx.zeros((M, N), dtype=dtype)
+    inp.fill_(float(ctx.get_rank() + 1) * 0.01)
+    rs_out = ctx.zeros((M_local, N), dtype=dtype)
+    gamma = torch.ones(N, device="cuda", dtype=dtype)
+
+    # RS comm volume only (no AG)
+    state.set_bytes((num_ranks - 1) * M_local * N * inp.element_size())
+
+    def _run():
+        # --- replace these two lines with the fused kernel call ---
+        dist.reduce_scatter_tensor(rs_out, inp, op=dist.ReduceOp.SUM)
+        rmsnorm(rs_out, gamma)
+        # --- end replacement site ---
+
+    def _preamble():
+        rs_out.zero_()
+
+    state.exec(_run, preamble_fn=_preamble)
+
+
+if __name__ == "__main__":
+    import iris.bench as _bench
+    print(f"[info] RMSNorm backend: {_RMSNORM_BACKEND}")
+    _bench.main()

--- a/benchmark/ops/bench_rs_rmsnorm.py
+++ b/benchmark/ops/bench_rs_rmsnorm.py
@@ -40,12 +40,16 @@ import iris.bench as bench
 # Use aiter's Triton RMSNorm if available; fall back to torch
 try:
     from aiter.ops.triton.rmsnorm import rms_norm as _aiter_rms_norm
+
     def rmsnorm(x, weight, eps=1e-6):
         return _aiter_rms_norm(x, weight, eps)
+
     _RMSNORM_BACKEND = "aiter-triton"
 except Exception:
+
     def rmsnorm(x, weight, eps=1e-6):
         return F.rms_norm(x, [x.shape[-1]], weight=weight, eps=eps)
+
     _RMSNORM_BACKEND = "torch"
 
 
@@ -144,5 +148,6 @@ def fused_ready_rs_rmsnorm(state, ctx):
 
 if __name__ == "__main__":
     import iris.bench as _bench
+
     print(f"[info] RMSNorm backend: {_RMSNORM_BACKEND}")
     _bench.main()

--- a/benchmark/ops/bench_sp_layer_e2e.py
+++ b/benchmark/ops/bench_sp_layer_e2e.py
@@ -46,15 +46,18 @@ import torch.nn.functional as F
 import iris.bench as bench
 from iris.ops import (
     FusedConfig,
-    matmul_reduce_scatter, matmul_reduce_scatter_preamble,
+    matmul_reduce_scatter,
+    matmul_reduce_scatter_preamble,
 )
 
 # Use aiter's Triton RMSNorm where available, fall back to torch
 try:
     from aiter.ops.triton.rmsnorm import rms_norm as _aiter_rms_norm
+
     def _rmsnorm(x, weight, eps=1e-6):
         return _aiter_rms_norm(x, weight, eps)
 except Exception:
+
     def _rmsnorm(x, weight, eps=1e-6):
         return F.rms_norm(x, [x.shape[-1]], weight=weight, eps=eps)
 
@@ -86,7 +89,7 @@ def unfused_gemm_rs_rmsnorm(state, ctx):
     # O_proj: each rank holds K_local columns of the weight
     A = torch.randn((M, K_local), device="cuda", dtype=dtype)
     B_out = torch.randn((K_local, N), device="cuda", dtype=dtype)
-    C_full = torch.empty((M, N), device="cuda", dtype=dtype)    # intermediate full GEMM output
+    C_full = torch.empty((M, N), device="cuda", dtype=dtype)  # intermediate full GEMM output
     C_local = torch.empty((M_local, N), device="cuda", dtype=dtype)  # RS output shard
 
     # RMSNorm weight (applied to the M_local shard in the SP region)

--- a/benchmark/ops/bench_sp_layer_e2e.py
+++ b/benchmark/ops/bench_sp_layer_e2e.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+End-to-end SP segment benchmark for GPT-OSS-120B.
+
+Models the SP segment between attention output and MoE input for GPT-OSS-120B:
+
+  O_proj (row-parallel): [M, K_local] x [K_local, N] → partial [M, N]
+    → Reduce-Scatter: [M/tp, N]
+    → RMSNorm: [M/tp, N]
+    → (MoE handles its own SP from here)
+
+  K = num_heads * head_dim = 64 * 64 = 4096
+  N = hidden_size = 2880
+
+GPT-OSS-120B is an MoE model (128 experts, top-4) whose MoE layer handles its
+own sequence parallelism internally (sequence_parallel_chunk at entry +
+tensor_model_parallel_all_gather at exit).  There is no All-Gather after
+RMSNorm and no column-parallel FFN GEMM — the MoE receives [M/tp, N] directly.
+
+Two benchmarks:
+
+  unfused_gemm_rs_rmsnorm
+      torch.mm + dist.reduce_scatter_tensor + aiter RMSNorm
+      Covers all M (decode / hybrid / prefill).
+
+  fused_gemm_rs_rmsnorm_iris
+      iris matmul_reduce_scatter (GEMM+RS fused, tile-sweep) + aiter RMSNorm.
+      Covers all M sizes; sweeps bm/bn tile configs.
+
+Shapes:
+  M:       sequence length  (32=decode, 896=hybrid, 2048=prefill)
+  N=2880:  hidden dimension
+  K=4096:  global K split across ranks (K_local = K // num_ranks)
+  M_local = M // num_ranks
+
+FLOPs = 2 * M * N * K_local  (single O_proj GEMM)
+Bytes = (num_ranks - 1) * M_local * N * element_size  (RS only)
+"""
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import iris.bench as bench
+from iris.ops import (
+    FusedConfig,
+    matmul_reduce_scatter, matmul_reduce_scatter_preamble,
+)
+
+# Use aiter's Triton RMSNorm where available, fall back to torch
+try:
+    from aiter.ops.triton.rmsnorm import rms_norm as _aiter_rms_norm
+    def _rmsnorm(x, weight, eps=1e-6):
+        return _aiter_rms_norm(x, weight, eps)
+except Exception:
+    def _rmsnorm(x, weight, eps=1e-6):
+        return F.rms_norm(x, [x.shape[-1]], weight=weight, eps=eps)
+
+
+# ---------------------------------------------------------------------------
+# Unfused baseline: torch.mm + NCCL RS + RMSNorm
+# ---------------------------------------------------------------------------
+
+
+@bench.register
+@bench.axis("num_ranks", [2, 4, 8])
+@bench.axis("M", [32, 896, 2048])
+@bench.axis("N", [2880])
+@bench.axis("K", [4096])
+@bench.axis("dtype", [torch.float16])
+def unfused_gemm_rs_rmsnorm(state, ctx):
+    M, N, K_global = state["M"], state["N"], state["K"]
+    dtype = state["dtype"]
+    num_ranks = ctx.get_num_ranks()
+
+    if M % num_ranks != 0:
+        state.skip(f"M={M} not divisible by num_ranks={num_ranks}")
+        return
+
+    K_local = K_global // num_ranks
+    M_local = M // num_ranks
+
+    # --- Allocate buffers ---
+    # O_proj: each rank holds K_local columns of the weight
+    A = torch.randn((M, K_local), device="cuda", dtype=dtype)
+    B_out = torch.randn((K_local, N), device="cuda", dtype=dtype)
+    C_full = torch.empty((M, N), device="cuda", dtype=dtype)    # intermediate full GEMM output
+    C_local = torch.empty((M_local, N), device="cuda", dtype=dtype)  # RS output shard
+
+    # RMSNorm weight (applied to the M_local shard in the SP region)
+    gamma = torch.ones(N, device="cuda", dtype=dtype)
+
+    # Single O_proj GEMM only (no FFN — MoE handles that)
+    state.set_flops(2 * M * N * K_local)
+    state.set_bytes((num_ranks - 1) * M_local * N * A.element_size())
+
+    def _run():
+        # 1. O_proj GEMM  (row-parallel: partial sum per rank)
+        torch.mm(A, B_out, out=C_full)
+        # 2. Reduce-Scatter  (sum partials; each rank receives M_local rows)
+        dist.reduce_scatter_tensor(C_local, C_full, op=dist.ReduceOp.SUM)
+        # 3. RMSNorm on local shard  (SP region: M_local rows per rank)
+        _rmsnorm(C_local, gamma)
+
+    state.exec(_run)
+
+
+# ---------------------------------------------------------------------------
+# iris GEMM+RS  |  aiter RMSNorm
+# ---------------------------------------------------------------------------
+
+
+@bench.register
+@bench.axis("num_ranks", [2, 4, 8])
+@bench.axis("M", [32, 896, 2048])
+@bench.axis("N", [2880])
+@bench.axis("K", [4096])
+@bench.axis("dtype", [torch.float16])
+@bench.axis("bm", [32, 64, 128])
+@bench.axis("bn", [64, 128])
+def fused_gemm_rs_rmsnorm_iris(state, ctx):
+    M, N, K_global = state["M"], state["N"], state["K"]
+    dtype = state["dtype"]
+    bm, bn = state["bm"], state["bn"]
+    num_ranks = ctx.get_num_ranks()
+
+    if M % num_ranks != 0:
+        state.skip(f"M={M} not divisible by num_ranks={num_ranks}")
+        return
+
+    if bm > M:
+        state.skip(f"bm={bm} > M={M}")
+        return
+    if bn > N:
+        state.skip(f"bn={bn} > N={N}")
+        return
+
+    K_local = K_global // num_ranks
+    M_local = M // num_ranks
+
+    # --- Allocate buffers in iris shared memory where required ---
+    A = ctx.zeros((M, K_local), dtype=dtype)
+    A.fill_(float(ctx.get_rank() + 1) * 0.01)
+    B_out = torch.randn((K_local, N), device="cuda", dtype=dtype)
+    # iris matmul_reduce_scatter writes the RS shard directly to C_local
+    C_local = ctx.zeros((M_local, N), dtype=dtype)
+
+    # RMSNorm weight
+    gamma = torch.ones(N, device="cuda", dtype=dtype)
+
+    # Tile config for the fused GEMM+RS kernel
+    rs_config = FusedConfig(
+        block_size_m=bm,
+        block_size_n=bn,
+        block_size_k=64,
+        group_size_m=4,
+        num_xcds=8,
+        all_reduce_variant="two_shot",  # RS kernel only implements two_shot
+    )
+    workspace = matmul_reduce_scatter_preamble(ctx, C_local, A, B_out, config=rs_config)
+
+    # Single O_proj GEMM only (no FFN — MoE handles that)
+    state.set_flops(2 * M * N * K_local)
+    state.set_bytes((num_ranks - 1) * M_local * N * A.element_size())
+
+    def _run():
+        # 1+2. Fused O_proj GEMM + Reduce-Scatter (single iris kernel)
+        workspace.prepared = False
+        matmul_reduce_scatter(ctx, C_local, A, B_out, config=rs_config, workspace=workspace)
+
+        # 3. RMSNorm on the RS output shard (M_local, N)
+        _rmsnorm(C_local, gamma)
+
+    def _preamble():
+        C_local.zero_()
+        if workspace.locks is not None:
+            workspace.locks.zero_()
+        if workspace.aux_buffer is not None:
+            workspace.aux_buffer.zero_()
+        workspace.prepared = True
+
+    state.exec(_run, preamble_fn=_preamble)
+
+
+if __name__ == "__main__":
+    bench.main()


### PR DESCRIPTION
## Summary

Add three Sequence Parallelism (SP) benchmarks targeting the GPT-OSS-120B MoE model. These cover the SP segment between attention output and MoE input:

```
O_proj (row-parallel): [M, K_local] x [K_local, N] → partial [M, N]
  → Reduce-Scatter → [M/tp, N]
  → RMSNorm on [M/tp, N]
  → (MoE receives [M/tp, N] directly — handles its own AG at exit)
```
K = 64 × 64 = 4096, N = 2880. M values: 32 (decode), 896 (hybrid), 2048 (prefill).

### New files

- **`benchmark/ops/bench_matmul_reduce_scatter_stages.py`** — Fused GEMM + Reduce-Scatter stage profiler. Compares unfused `torch.mm + dist.reduce_scatter_tensor` against iris `matmul_reduce_scatter` with tile-config sweep (bm × bn). Models the O_proj row-parallel GEMM followed by RS.

- **`benchmark/ops/bench_rs_rmsnorm.py`** — RS + RMSNorm stage profiler. Compares unfused NCCL `reduce_scatter_tensor` + aiter Triton RMSNorm against an iris shmem "fused-ready" variant (same ops but buffers allocated in iris shared memory, compatible with aiter fused kernel calling convention).

- **`benchmark/ops/bench_sp_layer_e2e.py`** — End-to-end SP segment benchmark combining all three stages (GEMM + RS + RMSNorm). Compares unfused `torch.mm + dist.reduce_scatter_tensor + RMSNorm` against fused `iris matmul_reduce_scatter + RMSNorm`, with tile-config sweep.

All three benchmarks use the `iris.bench` framework, sweep across TP degrees (2, 4, 8 ranks), and report FLOPs and communication bytes.

## Test plan

- [ ] Run `benchmark/ops/bench_matmul_reduce_scatter_stages.py` with 2, 4, 8 ranks
- [ ] Run `benchmark/ops/bench_rs_rmsnorm.py` with 2, 4, 8 ranks
- [ ] Run `benchmark/ops/bench_sp_layer_e2e.py` with 2, 4, 8 ranks