### PR TITLE
Improve topology detection performance

### DIFF
--- a/iris/device_utils.py
+++ b/iris/device_utils.py
@@ -11,25 +11,61 @@ architecture-aware APIs (``tl.extra.hip``) where available.
 
 import triton
 import triton.language as tl
-from triton.language.extra.hip import memrealtime, smid
 from triton.language.target_info import is_hip_cdna3, is_hip_cdna4
 
+try:
+    from triton.language.extra.hip import memrealtime as _memrealtime
+    from triton.language.extra.hip import smid as _smid
 
-@triton.jit
-def read_realtime():
-    """
-    Read GPU wall clock timestamp.
+    _HAS_HIP_INTRINSICS = True
+except ImportError:
+    _HAS_HIP_INTRINSICS = False
 
-    Returns a 64-bit value from the GPU's constant-frequency real-time
-    counter (100 MHz, unaffected by power states or clock gating).
 
-    Delegates to ``tl.extra.hip.memrealtime()`` which emits the correct
-    instruction for each architecture family.
+if _HAS_HIP_INTRINSICS:
 
-    Returns:
-        int64: Current timestamp in cycles (100 MHz constant clock)
-    """
-    return memrealtime()
+    @triton.jit
+    def read_realtime():
+        """
+        Read GPU wall clock timestamp.
+
+        Returns a 64-bit value from the GPU's constant-frequency real-time
+        counter (100 MHz, unaffected by power states or clock gating).
+
+        Delegates to ``tl.extra.hip.memrealtime()`` which emits the correct
+        instruction for each architecture family.
+
+        Returns:
+            int64: Current timestamp in cycles (100 MHz constant clock)
+        """
+        return _memrealtime()
+
+    @triton.jit
+    def get_cu_id():
+        """
+        Get compute-unit / workgroup-processor ID for the current wave.
+
+        Delegates to ``tl.extra.hip.smid()`` which reads the appropriate
+        hardware register for each architecture family (CU_ID on CDNA,
+        WGP_ID on RDNA).
+
+        Returns:
+            int32: CU / WGP ID for the current execution
+        """
+        return _smid()
+else:
+
+    @triton.jit
+    def read_realtime():
+        """Fallback stub when HIP intrinsics are missing."""
+        tl.static_assert(False, "memrealtime is unavailable in this Triton build")
+        return tl.cast(0, tl.int64)
+
+    @triton.jit
+    def get_cu_id():
+        """Fallback stub when HIP intrinsics are missing."""
+        tl.static_assert(False, "smid is unavailable in this Triton build")
+        return tl.cast(0, tl.int32)
 
 
 @triton.jit
@@ -54,18 +90,3 @@ def get_xcc_id():
         )
     else:
         return tl.cast(0, tl.int32)
-
-
-@triton.jit
-def get_cu_id():
-    """
-    Get compute-unit / workgroup-processor ID for the current wave.
-
-    Delegates to ``tl.extra.hip.smid()`` which reads the appropriate
-    hardware register for each architecture family (CU_ID on CDNA,
-    WGP_ID on RDNA).
-
-    Returns:
-        int32: CU / WGP ID for the current execution
-    """
-    return smid()

--- a/iris/topology.py
+++ b/iris/topology.py
@@ -168,18 +168,17 @@ def _get_nvml_handle_by_pci(pci_bus_id: str):
     This bypasses index-based lookup entirely and is immune to
     CUDA_VISIBLE_DEVICES remapping.  Returns None on failure.
     """
+    norm = _normalize_pci_bus_id(pci_bus_id)
     try:
         import pynvml
+
+        # nvmlDeviceGetHandleByPciBusId expects full domain:bus:dev.fn
+        if len(norm.split(":")) == 2:
+            norm = f"0000:{norm}"
+
+        return pynvml.nvmlDeviceGetHandleByPciBusId(norm.encode())
     except ImportError:
         return None
-
-    norm = _normalize_pci_bus_id(pci_bus_id)
-    # nvmlDeviceGetHandleByPciBusId expects full domain:bus:dev.fn
-    if len(norm.split(":")) == 2:
-        norm = f"0000:{norm}"
-
-    try:
-        return pynvml.nvmlDeviceGetHandleByPciBusId(norm.encode())
     except Exception as e:
         logger.debug("nvmlDeviceGetHandleByPciBusId(%s) failed: %s", norm, e)
         return None
@@ -197,22 +196,25 @@ def _get_amdsmi_handle_by_pci(pci_bus_id: str, all_handles=None):
     """
     try:
         import amdsmi
+
+        if all_handles is None:
+            all_handles = amdsmi.amdsmi_get_processor_handles()
+
+        norm = _normalize_pci_bus_id(pci_bus_id)
+
+        for handle in all_handles:
+            try:
+                bdf = amdsmi.amdsmi_get_gpu_device_bdf(handle)
+                if bdf and _normalize_pci_bus_id(str(bdf)) == norm:
+                    return handle
+            except Exception:
+                continue
+        return None
     except ImportError:
         return None
-
-    if all_handles is None:
-        all_handles = amdsmi.amdsmi_get_processor_handles()
-
-    norm = _normalize_pci_bus_id(pci_bus_id)
-
-    for handle in all_handles:
-        try:
-            bdf = amdsmi.amdsmi_get_gpu_device_bdf(handle)
-            if bdf and _normalize_pci_bus_id(str(bdf)) == norm:
-                return handle
-        except Exception:
-            continue
-    return None
+    except Exception as e:
+        logger.debug("amdsmi handle lookup by PCI bus ID (%s) failed: %s", pci_bus_id, e)
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -254,63 +256,58 @@ def _nvidia_get_gpu_fabric_info(gpu_id: int, pci_bus_id: str = "") -> FabricInfo
     try:
         import pynvml
 
-        pynvml.nvmlInit()
+        # --- Resolve handle: prefer PCI bus ID, fall back to physical index ---
+        handle = None
+        if pci_bus_id and pci_bus_id != "unknown":
+            handle = _get_nvml_handle_by_pci(pci_bus_id)
+
+        if handle is None:
+            physical_idx = _logical_to_physical_gpu_index(gpu_id, "nvidia")
+            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_idx)
+
+        fabric_info = None
         try:
-            # --- Resolve handle: prefer PCI bus ID, fall back to physical index ---
-            handle = None
-            if pci_bus_id and pci_bus_id != "unknown":
-                handle = _get_nvml_handle_by_pci(pci_bus_id)
+            info_struct = pynvml.c_nvmlGpuFabricInfo_v2_t()
+            pynvml.nvmlDeviceGetGpuFabricInfoV(handle, info_struct)
+            fabric_info = info_struct
+        except (AttributeError, TypeError, pynvml.NVMLError):
+            # GPU doesn't support fabric
+            return FabricInfo()
 
-            if handle is None:
-                physical_idx = _logical_to_physical_gpu_index(gpu_id, "nvidia")
-                handle = pynvml.nvmlDeviceGetHandleByIndex(physical_idx)
+        if fabric_info is None:
+            return FabricInfo()
 
-            fabric_info = None
-            try:
-                info_struct = pynvml.c_nvmlGpuFabricInfo_v2_t()
-                pynvml.nvmlDeviceGetGpuFabricInfoV(handle, info_struct)
-                fabric_info = info_struct
-            except (AttributeError, TypeError, pynvml.NVMLError):
-                # GPU doesn't support fabric
-                return FabricInfo()
+        # Check registration state — must be COMPLETED (value 3)
+        state = getattr(fabric_info, "state", None)
+        if state is not None and state != 3:
+            return FabricInfo()
 
-            if fabric_info is None:
-                return FabricInfo()
+        # Check status — must be SUCCESS (value 0)
+        status = getattr(fabric_info, "status", None)
+        if status is not None and status != 0:
+            return FabricInfo()
 
-            # Check registration state — must be COMPLETED (value 3)
-            state = getattr(fabric_info, "state", None)
-            if state is not None and state != 3:
-                return FabricInfo()
+        # Extract clusterUuid
+        cluster_uuid_raw = getattr(fabric_info, "clusterUuid", None)
+        if cluster_uuid_raw is None:
+            return FabricInfo()
 
-            # Check status — must be SUCCESS (value 0)
-            status = getattr(fabric_info, "status", None)
-            if status is not None and status != 0:
-                return FabricInfo()
+        if isinstance(cluster_uuid_raw, bytes):
+            cluster_uuid_hex = cluster_uuid_raw.hex()
+        elif isinstance(cluster_uuid_raw, (list, tuple)):
+            cluster_uuid_hex = bytes(cluster_uuid_raw).hex()
+        else:
+            cluster_uuid_hex = str(cluster_uuid_raw)
 
-            # Extract clusterUuid
-            cluster_uuid_raw = getattr(fabric_info, "clusterUuid", None)
-            if cluster_uuid_raw is None:
-                return FabricInfo()
+        if all(c == "0" for c in cluster_uuid_hex):
+            return FabricInfo()
 
-            if isinstance(cluster_uuid_raw, bytes):
-                cluster_uuid_hex = cluster_uuid_raw.hex()
-            elif isinstance(cluster_uuid_raw, (list, tuple)):
-                cluster_uuid_hex = bytes(cluster_uuid_raw).hex()
-            else:
-                cluster_uuid_hex = str(cluster_uuid_raw)
+        clique_id = getattr(fabric_info, "cliqueId", 0)
 
-            if all(c == "0" for c in cluster_uuid_hex):
-                return FabricInfo()
-
-            clique_id = getattr(fabric_info, "cliqueId", 0)
-
-            return FabricInfo(
-                cluster_uuid=cluster_uuid_hex,
-                clique_id=int(clique_id),
-            )
-        finally:
-            pynvml.nvmlShutdown()
-
+        return FabricInfo(
+            cluster_uuid=cluster_uuid_hex,
+            clique_id=int(clique_id),
+        )
     except ImportError:
         logger.debug("pynvml not available, skipping NVML fabric info")
     except Exception as e:
@@ -319,13 +316,16 @@ def _nvidia_get_gpu_fabric_info(gpu_id: int, pci_bus_id: str = "") -> FabricInfo
     return FabricInfo()
 
 
-def get_gpu_fabric_info(gpu_id: int, vendor: str, pci_bus_id: str = "") -> FabricInfo:
+def _get_gpu_fabric_info(gpu_id: int, vendor: str, pci_bus_id: str = "") -> FabricInfo:
     """
     Get GPU fabric domain info for the given device.
 
     Dispatches to the appropriate vendor-specific implementation:
         AMD:    amdsmi_get_gpu_fabric_info (ppod_id, vpod_id)
         NVIDIA: nvmlDeviceGetGpuFabricInfoV (clusterUuid, cliqueId)
+
+    Caller is responsible for wrapping the discovery scope in
+    _outer_init_vendor_lib() / _outer_shutdown_vendor_lib().
 
     Args:
         gpu_id: Local GPU device index.
@@ -335,12 +335,12 @@ def get_gpu_fabric_info(gpu_id: int, vendor: str, pci_bus_id: str = "") -> Fabri
     Returns:
         FabricInfo identifying the fabric domain this GPU belongs to.
     """
+    if vendor not in ("amd", "nvidia"):
+        return FabricInfo()
+
     if vendor == "amd":
         return _amd_get_gpu_fabric_info(gpu_id, pci_bus_id=pci_bus_id)
-    elif vendor == "nvidia":
-        return _nvidia_get_gpu_fabric_info(gpu_id, pci_bus_id=pci_bus_id)
-    else:
-        return FabricInfo()
+    return _nvidia_get_gpu_fabric_info(gpu_id, pci_bus_id=pci_bus_id)
 
 
 def _normalize_pci_bus_id(bus_id: str) -> str:
@@ -585,6 +585,57 @@ def _detect_vendor() -> str:
     return "unknown"
 
 
+def _outer_init_vendor_lib(vendor: str) -> None:
+    """
+    Initialize the vendor library for the duration of an outer scope
+    (for example, TopologyDiscovery.discover).
+
+    Failures are logged but not raised. This is defensive — if init fails,
+    the helpers called inside the scope will themselves raise and be caught
+    by their own except Exception clauses, falling back gracefully.
+    """
+    if vendor == "nvidia":
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("nvmlInit() failed: %s", e)
+    elif vendor == "amd":
+        try:
+            import amdsmi
+
+            amdsmi.amdsmi_init()
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("amdsmi_init() failed: %s", e)
+
+
+def _outer_shutdown_vendor_lib(vendor: str) -> None:
+    """Counterpart to _outer_init_vendor_lib. Safe to call unconditionally in a finally block."""
+    if vendor == "nvidia":
+        try:
+            import pynvml
+
+            pynvml.nvmlShutdown()
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("nvmlShutdown() failed: %s", e)
+    elif vendor == "amd":
+        try:
+            import amdsmi
+
+            amdsmi.amdsmi_shut_down()
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("amdsmi_shut_down() failed: %s", e)
+
+
 def _get_total_memory_mb(gpu_id: int) -> int:
     """
     Get total GPU memory in MB, compatible across PyTorch versions.
@@ -618,16 +669,12 @@ def _get_pci_bus_id(device_idx: int, vendor: str) -> str:
         try:
             import pynvml
 
-            pynvml.nvmlInit()
-            try:
-                handle = pynvml.nvmlDeviceGetHandleByIndex(physical_idx)
-                pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
-                bus_id = pci_info.busId
-                if isinstance(bus_id, bytes):
-                    bus_id = bus_id.decode("utf-8")
-                return _normalize_pci_bus_id(bus_id)
-            finally:
-                pynvml.nvmlShutdown()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_idx)
+            pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+            bus_id = pci_info.busId
+            if isinstance(bus_id, bytes):
+                bus_id = bus_id.decode("utf-8")
+            return _normalize_pci_bus_id(bus_id)
         except ImportError:
             logger.debug("pynvml not available")
         except Exception as e:
@@ -642,21 +689,17 @@ def _get_pci_bus_id(device_idx: int, vendor: str) -> str:
         try:
             import amdsmi
 
-            amdsmi.amdsmi_init()
-            try:
-                handles = amdsmi.amdsmi_get_processor_handles()
-                if 0 <= physical_idx < len(handles):
-                    bus_id = amdsmi.amdsmi_get_gpu_device_bdf(handles[physical_idx])
-                    if bus_id:
-                        return _normalize_pci_bus_id(str(bus_id))
-                else:
-                    logger.debug(
-                        "physical_idx %d out of range (%d GPUs)",
-                        physical_idx,
-                        len(handles),
-                    )
-            finally:
-                amdsmi.amdsmi_shut_down()
+            handles = amdsmi.amdsmi_get_processor_handles()
+            if 0 <= physical_idx < len(handles):
+                bus_id = amdsmi.amdsmi_get_gpu_device_bdf(handles[physical_idx])
+                if bus_id:
+                    return _normalize_pci_bus_id(str(bus_id))
+            else:
+                logger.debug(
+                    "physical_idx %d out of range (%d GPUs)",
+                    physical_idx,
+                    len(handles),
+                )
         except ImportError:
             logger.debug("amdsmi not available")
         except Exception as e:
@@ -691,21 +734,17 @@ def _get_gpu_uuid(device_idx: int, vendor: str, pci_bus_id: str = "") -> str:
         try:
             import pynvml
 
-            pynvml.nvmlInit()
-            try:
-                # Prefer PCI-based resolution — immune to CUDA_VISIBLE_DEVICES
-                handle = None
-                if pci_bus_id and pci_bus_id != "unknown":
-                    handle = _get_nvml_handle_by_pci(pci_bus_id)
-                if handle is None:
-                    handle = pynvml.nvmlDeviceGetHandleByIndex(physical_idx)
+            # Prefer PCI-based resolution — immune to CUDA_VISIBLE_DEVICES
+            handle = None
+            if pci_bus_id and pci_bus_id != "unknown":
+                handle = _get_nvml_handle_by_pci(pci_bus_id)
+            if handle is None:
+                handle = pynvml.nvmlDeviceGetHandleByIndex(physical_idx)
 
-                uuid = pynvml.nvmlDeviceGetUUID(handle)
-                if isinstance(uuid, bytes):
-                    uuid = uuid.decode("utf-8")
-                return uuid
-            finally:
-                pynvml.nvmlShutdown()
+            uuid = pynvml.nvmlDeviceGetUUID(handle)
+            if isinstance(uuid, bytes):
+                uuid = uuid.decode("utf-8")
+            return uuid
         except ImportError:
             logger.debug("pynvml not available")
         except Exception as e:
@@ -720,28 +759,24 @@ def _get_gpu_uuid(device_idx: int, vendor: str, pci_bus_id: str = "") -> str:
         try:
             import amdsmi
 
-            amdsmi.amdsmi_init()
-            try:
-                # Prefer PCI-based resolution
-                handle = None
-                if pci_bus_id and pci_bus_id != "unknown":
-                    handle = _get_amdsmi_handle_by_pci(pci_bus_id)
-                if handle is None:
-                    handles = amdsmi.amdsmi_get_processor_handles()
-                    if 0 <= physical_idx < len(handles):
-                        handle = handles[physical_idx]
+            # Prefer PCI-based resolution
+            handle = None
+            if pci_bus_id and pci_bus_id != "unknown":
+                handle = _get_amdsmi_handle_by_pci(pci_bus_id)
+            if handle is None:
+                handles = amdsmi.amdsmi_get_processor_handles()
+                if 0 <= physical_idx < len(handles):
+                    handle = handles[physical_idx]
 
-                if handle is not None:
-                    uuid = amdsmi.amdsmi_get_gpu_device_uuid(handle)
-                    if uuid:
-                        return str(uuid)
-                else:
-                    logger.debug(
-                        "physical_idx %d out of range or PCI resolve failed",
-                        physical_idx,
-                    )
-            finally:
-                amdsmi.amdsmi_shut_down()
+            if handle is not None:
+                uuid = amdsmi.amdsmi_get_gpu_device_uuid(handle)
+                if uuid:
+                    return str(uuid)
+            else:
+                logger.debug(
+                    "physical_idx %d out of range or PCI resolve failed",
+                    physical_idx,
+                )
         except ImportError:
             logger.debug("amdsmi not available")
         except Exception as e:
@@ -902,47 +937,41 @@ def _parse_nvidia_topo(local_pci_bus_ids: List[str]) -> Optional[List[List[int]]
     try:
         import pynvml
 
-        pynvml.nvmlInit()
-        try:
-            # Resolve local PCI bus IDs directly to NVML handles
-            handles = []
-            for pci in local_pci_bus_ids:
-                norm = _normalize_pci_bus_id(pci)
-                if len(norm.split(":")) == 2:
-                    norm = f"0000:{norm}"
+        # Resolve local PCI bus IDs directly to NVML handles
+        handles = []
+        for pci in local_pci_bus_ids:
+            norm = _normalize_pci_bus_id(pci)
+            if len(norm.split(":")) == 2:
+                norm = f"0000:{norm}"
+            try:
+                handle = pynvml.nvmlDeviceGetHandleByPciBusId(norm.encode())
+                handles.append(handle)
+            except pynvml.NVMLError as e:
+                logger.warning("Could not get NVML handle for PCI %s: %s", pci, e)
+                return None
+
+        # Build the matrix
+        matrix = [[IntraNodeLinkType.UNKNOWN] * num_local for _ in range(num_local)]
+        for i in range(num_local):
+            for j in range(num_local):
+                if i == j:
+                    matrix[i][j] = IntraNodeLinkType.SELF
+                    continue
+
+                # NVLink takes priority over PCIe topology level
+                if _nvml_check_nvlink(handles[i], handles[j], pynvml):
+                    matrix[i][j] = IntraNodeLinkType.NVLINK
+                    continue
+
                 try:
-                    handle = pynvml.nvmlDeviceGetHandleByPciBusId(norm.encode())
-                    handles.append(handle)
-                except pynvml.NVMLError as e:
-                    logger.warning("Could not get NVML handle for PCI %s: %s", pci, e)
-                    return None
+                    level = pynvml.nvmlDeviceGetTopologyCommonAncestor(handles[i], handles[j])
+                    matrix[i][j] = _NVML_TOPO_TO_LINK.get(level, IntraNodeLinkType.UNKNOWN)
+                except pynvml.NVMLError:
+                    matrix[i][j] = IntraNodeLinkType.UNKNOWN
 
-            # Build the matrix
-            matrix = [[IntraNodeLinkType.UNKNOWN] * num_local for _ in range(num_local)]
-            for i in range(num_local):
-                for j in range(num_local):
-                    if i == j:
-                        matrix[i][j] = IntraNodeLinkType.SELF
-                        continue
-
-                    # NVLink takes priority over PCIe topology level
-                    if _nvml_check_nvlink(handles[i], handles[j], pynvml):
-                        matrix[i][j] = IntraNodeLinkType.NVLINK
-                        continue
-
-                    try:
-                        level = pynvml.nvmlDeviceGetTopologyCommonAncestor(handles[i], handles[j])
-                        matrix[i][j] = _NVML_TOPO_TO_LINK.get(level, IntraNodeLinkType.UNKNOWN)
-                    except pynvml.NVMLError:
-                        matrix[i][j] = IntraNodeLinkType.UNKNOWN
-
-            return matrix
-        finally:
-            pynvml.nvmlShutdown()
-
+        return matrix
     except ImportError:
         logger.debug("pynvml not available for topology query")
-        return None
     except Exception as e:
         logger.debug("NVML topology query failed: %s", e)
         return None
@@ -963,79 +992,71 @@ def _parse_amd_topo(local_pci_bus_ids: List[str]) -> Optional[List[List[int]]]:
     try:
         import amdsmi
 
-        amdsmi.amdsmi_init()
-        try:
-            all_handles = amdsmi.amdsmi_get_processor_handles()
+        all_handles = amdsmi.amdsmi_get_processor_handles()
 
-            # Build BDF -> handle map for all physical GPUs
-            bdf_to_handle = {}
-            for handle in all_handles:
-                try:
-                    bdf = amdsmi.amdsmi_get_gpu_device_bdf(handle)
-                    if bdf:
-                        bdf_to_handle[_normalize_pci_bus_id(str(bdf))] = handle
-                except Exception:
+        # Build BDF -> handle map for all physical GPUs
+        bdf_to_handle = {}
+        for handle in all_handles:
+            try:
+                bdf = amdsmi.amdsmi_get_gpu_device_bdf(handle)
+                if bdf:
+                    bdf_to_handle[_normalize_pci_bus_id(str(bdf))] = handle
+            except Exception:
+                continue
+
+        # Resolve local PCI bus IDs to amdsmi handles
+        handles = []
+        for pci in local_pci_bus_ids:
+            norm = _normalize_pci_bus_id(pci)
+            handle = bdf_to_handle.get(norm)
+            if handle is None:
+                logger.warning(
+                    "Could not find amdsmi handle for PCI %s. Known BDFs: %s",
+                    pci,
+                    list(bdf_to_handle.keys()),
+                )
+                return None
+            handles.append(handle)
+
+        # Pre-compute XGMI neighbor sets for each local GPU.
+        # amdsmi_get_link_topology_nearest returns all GPUs reachable
+        # via a given link type from a source GPU.
+        xgmi_neighbors: List[Set[str]] = []
+        for handle in handles:
+            neighbors: Set[str] = set()
+            try:
+                result = amdsmi.amdsmi_get_link_topology_nearest(handle, amdsmi.AmdSmiLinkType.AMDSMI_LINK_TYPE_XGMI)
+                for peer in result.get("processor_list", []):
+                    try:
+                        peer_bdf = amdsmi.amdsmi_get_gpu_device_bdf(peer)
+                        if peer_bdf:
+                            neighbors.add(_normalize_pci_bus_id(str(peer_bdf)))
+                    except Exception:
+                        continue
+            except Exception:
+                pass  # No XGMI on this GPU (PCIe-only system)
+            xgmi_neighbors.append(neighbors)
+
+        # Normalized BDFs for each local device index
+        local_bdfs = [_normalize_pci_bus_id(pci) for pci in local_pci_bus_ids]
+
+        # Build the matrix
+        matrix = [[IntraNodeLinkType.UNKNOWN] * num_local for _ in range(num_local)]
+        for i in range(num_local):
+            for j in range(num_local):
+                if i == j:
+                    matrix[i][j] = IntraNodeLinkType.SELF
                     continue
 
-            # Resolve local PCI bus IDs to amdsmi handles
-            handles = []
-            for pci in local_pci_bus_ids:
-                norm = _normalize_pci_bus_id(pci)
-                handle = bdf_to_handle.get(norm)
-                if handle is None:
-                    logger.warning(
-                        "Could not find amdsmi handle for PCI %s. Known BDFs: %s",
-                        pci,
-                        list(bdf_to_handle.keys()),
-                    )
-                    return None
-                handles.append(handle)
+                # Check if GPU j's BDF is in GPU i's XGMI neighbor set
+                if local_bdfs[j] in xgmi_neighbors[i]:
+                    matrix[i][j] = IntraNodeLinkType.NVLINK  # XGMI maps to NVLINK enum
+                else:
+                    matrix[i][j] = IntraNodeLinkType.PCIE_SWITCH
 
-            # Pre-compute XGMI neighbor sets for each local GPU.
-            # amdsmi_get_link_topology_nearest returns all GPUs reachable
-            # via a given link type from a source GPU.
-            xgmi_neighbors: List[Set[str]] = []
-            for handle in handles:
-                neighbors: Set[str] = set()
-                try:
-                    result = amdsmi.amdsmi_get_link_topology_nearest(
-                        handle, amdsmi.AmdSmiLinkType.AMDSMI_LINK_TYPE_XGMI
-                    )
-                    for peer in result.get("processor_list", []):
-                        try:
-                            peer_bdf = amdsmi.amdsmi_get_gpu_device_bdf(peer)
-                            if peer_bdf:
-                                neighbors.add(_normalize_pci_bus_id(str(peer_bdf)))
-                        except Exception:
-                            continue
-                except Exception:
-                    pass  # No XGMI on this GPU (PCIe-only system)
-                xgmi_neighbors.append(neighbors)
-
-            # Normalized BDFs for each local device index
-            local_bdfs = [_normalize_pci_bus_id(pci) for pci in local_pci_bus_ids]
-
-            # Build the matrix
-            matrix = [[IntraNodeLinkType.UNKNOWN] * num_local for _ in range(num_local)]
-            for i in range(num_local):
-                for j in range(num_local):
-                    if i == j:
-                        matrix[i][j] = IntraNodeLinkType.SELF
-                        continue
-
-                    # Check if GPU j's BDF is in GPU i's XGMI neighbor set
-                    if local_bdfs[j] in xgmi_neighbors[i]:
-                        matrix[i][j] = IntraNodeLinkType.NVLINK  # XGMI maps to NVLINK enum
-                    else:
-                        matrix[i][j] = IntraNodeLinkType.PCIE_SWITCH
-
-            return matrix
-        finally:
-            amdsmi.amdsmi_shut_down()
-
+        return matrix
     except ImportError:
         logger.debug("amdsmi not available for topology query")
-        return None
     except Exception as e:
         logger.debug("amdsmi topology query failed: %s", e)
         return None
@@ -1143,53 +1164,55 @@ class TopologyDiscovery:
             f"[Rank {self.rank}] Starting topology discovery on {hostname}, GPU {self.gpu_id}, vendor={vendor}"
         )
 
-        # Probe local GPU info
-        device_name = torch.cuda.get_device_name(self.gpu_id)
-        total_memory_mb = _get_total_memory_mb(self.gpu_id)
-        pci_bus_id = _get_pci_bus_id(self.gpu_id, vendor)
-        # Pass PCI bus ID to UUID query for PCI-based handle resolution
-        gpu_uuid = _get_gpu_uuid(self.gpu_id, vendor, pci_bus_id=pci_bus_id)
-        # Pass PCI bus ID
-        numa_node = _get_numa_node(pci_bus_id)
+        _outer_init_vendor_lib(vendor)
+        try:
+            # Probe local GPU info
+            device_name = torch.cuda.get_device_name(self.gpu_id)
+            total_memory_mb = _get_total_memory_mb(self.gpu_id)
+            pci_bus_id = _get_pci_bus_id(self.gpu_id, vendor)
+            # Pass PCI bus ID to UUID query for PCI-based handle resolution
+            gpu_uuid = _get_gpu_uuid(self.gpu_id, vendor, pci_bus_id=pci_bus_id)
+            # Pass PCI bus ID
+            numa_node = _get_numa_node(pci_bus_id)
 
-        # Query fabric info — pass PCI bus ID for PCI-based handle resolution
-        fabric_info = get_gpu_fabric_info(self.gpu_id, vendor, pci_bus_id=pci_bus_id)
-        logger.debug(
-            f"[Rank {self.rank}] Fabric info: cluster_uuid={fabric_info.cluster_uuid}, "
-            f"clique_id={fabric_info.clique_id}, domain_key={fabric_info.domain_key}"
-        )
-
-        local_gpu_info = GPUInfo(
-            global_rank=self.rank,
-            local_rank=self.gpu_id,
-            hostname=hostname,
-            gpu_id=self.gpu_id,
-            pci_bus_id=pci_bus_id,
-            device_name=device_name,
-            total_memory_mb=total_memory_mb,
-            numa_node=numa_node,
-            vendor=vendor,
-            uuid=gpu_uuid,
-            fabric_info=fabric_info,
-        )
-
-        # Probe node-level info
-        # Gather PCI bus IDs for ALL visible GPUs on this node (not just this rank's).
-        # This is needed for correct CLI tool output remapping.
-        num_local_gpus = torch.cuda.device_count()
-        if num_local_gpus <= 1 and self.world_size > 1:
-            logger.warning(
-                f"[Rank {self.rank}] torch.cuda.device_count() = {num_local_gpus}. "
-                f"CUDA_VISIBLE_DEVICES may be restricting GPU visibility. "
-                f"Intra-node topology detection will be limited."
+            # Query fabric info — pass PCI bus ID for PCI-based handle resolution
+            fabric_info = _get_gpu_fabric_info(self.gpu_id, vendor, pci_bus_id=pci_bus_id)
+            logger.debug(
+                f"[Rank {self.rank}] Fabric info: cluster_uuid={fabric_info.cluster_uuid}, "
+                f"clique_id={fabric_info.clique_id}, domain_key={fabric_info.domain_key}"
             )
 
-        local_pci_bus_ids = []
-        for dev_idx in range(num_local_gpus):
-            local_pci_bus_ids.append(_get_pci_bus_id(dev_idx, vendor))
+            local_gpu_info = GPUInfo(
+                global_rank=self.rank,
+                local_rank=self.gpu_id,
+                hostname=hostname,
+                gpu_id=self.gpu_id,
+                pci_bus_id=pci_bus_id,
+                device_name=device_name,
+                total_memory_mb=total_memory_mb,
+                numa_node=numa_node,
+                vendor=vendor,
+                uuid=gpu_uuid,
+                fabric_info=fabric_info,
+            )
 
-        has_ib, ib_devices = _detect_infiniband()
-        link_types, p2p_access = _detect_intra_node_topology(local_pci_bus_ids, vendor)
+            # Probe node-level info
+            # Gather PCI bus IDs for ALL visible GPUs on this node (not just this rank's).
+            # This is needed for correct CLI tool output remapping.
+            num_local_gpus = torch.cuda.device_count()
+            if num_local_gpus <= 1 and self.world_size > 1:
+                logger.warning(
+                    f"[Rank {self.rank}] torch.cuda.device_count() = {num_local_gpus}. "
+                    f"CUDA_VISIBLE_DEVICES may be restricting GPU visibility. "
+                    f"Intra-node topology detection will be limited."
+                )
+
+            local_pci_bus_ids = [_get_pci_bus_id(i, vendor) for i in range(num_local_gpus)]
+
+            has_ib, ib_devices = _detect_infiniband()
+            link_types, p2p_access = _detect_intra_node_topology(local_pci_bus_ids, vendor)
+        finally:
+            _outer_shutdown_vendor_lib(vendor)
 
         # All-gather
         local_gpu_json = json.dumps(local_gpu_info.to_dict())

--- a/tests/unittests/test_topology.py
+++ b/tests/unittests/test_topology.py
@@ -10,12 +10,17 @@ gracefully if the environment isn't set up.
 """
 
 import json
+import builtins
+import logging
 import socket
+import sys
+import types
 
 import pytest
 import torch
 import torch.distributed as dist
 
+import iris.topology as topology
 from iris.topology import (
     FabricInfo,
     GPUInfo,
@@ -40,6 +45,127 @@ def get_rank():
 
 def get_world_size():
     return dist.get_world_size() if dist.is_initialized() else 1
+
+
+def _make_fake_pynvml():
+    module = types.ModuleType("pynvml")
+    module.init_calls = 0
+    module.shutdown_calls = 0
+    module.pci_by_handle = {
+        "gpu0": "0000:41:00.0",
+        "gpu1": "0000:42:00.0",
+    }
+    module.handle_by_pci = {pci: handle for handle, pci in module.pci_by_handle.items()}
+    module.handle_by_index = {0: "gpu0", 1: "gpu1"}
+    module.nvlink_remote = {
+        "gpu0": "0000:42:00.0",
+        "gpu1": "0000:41:00.0",
+    }
+
+    class NVMLError(Exception):
+        pass
+
+    class FakeFabricInfo:
+        def __init__(self):
+            self.state = 0
+            self.status = 0
+            self.clusterUuid = b""
+            self.cliqueId = 0
+
+    def nvmlInit():
+        module.init_calls += 1
+
+    def nvmlShutdown():
+        module.shutdown_calls += 1
+
+    def nvmlDeviceGetHandleByIndex(index):
+        return module.handle_by_index[index]
+
+    def nvmlDeviceGetHandleByPciBusId(bus_id):
+        key = bus_id.decode("utf-8") if isinstance(bus_id, bytes) else str(bus_id)
+        return module.handle_by_pci[key.lower()]
+
+    def nvmlDeviceGetPciInfo(handle):
+        return types.SimpleNamespace(busId=module.pci_by_handle[handle].encode("utf-8"))
+
+    def nvmlDeviceGetUUID(handle):
+        return f"uuid-{handle}".encode("utf-8")
+
+    def nvmlDeviceGetGpuFabricInfoV(handle, info_struct):
+        info_struct.state = 3
+        info_struct.status = 0
+        info_struct.clusterUuid = bytes.fromhex("01" * 16)
+        info_struct.cliqueId = 7
+
+    def nvmlDeviceGetNvLinkState(handle, link):
+        if link == 0:
+            return 1
+        raise NVMLError("no more links")
+
+    def nvmlDeviceGetNvLinkRemotePciInfo(handle, link):
+        if link == 0:
+            return types.SimpleNamespace(busId=module.nvlink_remote[handle].encode("utf-8"))
+        raise NVMLError("no remote link")
+
+    def nvmlDeviceGetTopologyCommonAncestor(handle_a, handle_b):
+        return 30
+
+    module.NVMLError = NVMLError
+    module.c_nvmlGpuFabricInfo_v2_t = FakeFabricInfo
+    module.nvmlInit = nvmlInit
+    module.nvmlShutdown = nvmlShutdown
+    module.nvmlDeviceGetHandleByIndex = nvmlDeviceGetHandleByIndex
+    module.nvmlDeviceGetHandleByPciBusId = nvmlDeviceGetHandleByPciBusId
+    module.nvmlDeviceGetPciInfo = nvmlDeviceGetPciInfo
+    module.nvmlDeviceGetUUID = nvmlDeviceGetUUID
+    module.nvmlDeviceGetGpuFabricInfoV = nvmlDeviceGetGpuFabricInfoV
+    module.nvmlDeviceGetNvLinkState = nvmlDeviceGetNvLinkState
+    module.nvmlDeviceGetNvLinkRemotePciInfo = nvmlDeviceGetNvLinkRemotePciInfo
+    module.nvmlDeviceGetTopologyCommonAncestor = nvmlDeviceGetTopologyCommonAncestor
+
+    return module
+
+
+def _make_fake_amdsmi():
+    module = types.ModuleType("amdsmi")
+    module.init_calls = 0
+    module.shutdown_calls = 0
+    module.handles = ["gpu0", "gpu1"]
+    module.bdf_by_handle = {
+        "gpu0": "0000:41:00.0",
+        "gpu1": "0000:42:00.0",
+    }
+
+    class AmdSmiLinkType:
+        AMDSMI_LINK_TYPE_XGMI = "xgmi"
+
+    def amdsmi_init():
+        module.init_calls += 1
+
+    def amdsmi_shut_down():
+        module.shutdown_calls += 1
+
+    def amdsmi_get_processor_handles():
+        return module.handles
+
+    def amdsmi_get_gpu_device_bdf(handle):
+        return module.bdf_by_handle[handle]
+
+    def amdsmi_get_gpu_device_uuid(handle):
+        return f"amd-{handle}"
+
+    def amdsmi_get_link_topology_nearest(handle, link_type):
+        return {"processor_list": []}
+
+    module.AmdSmiLinkType = AmdSmiLinkType
+    module.amdsmi_init = amdsmi_init
+    module.amdsmi_shut_down = amdsmi_shut_down
+    module.amdsmi_get_processor_handles = amdsmi_get_processor_handles
+    module.amdsmi_get_gpu_device_bdf = amdsmi_get_gpu_device_bdf
+    module.amdsmi_get_gpu_device_uuid = amdsmi_get_gpu_device_uuid
+    module.amdsmi_get_link_topology_nearest = amdsmi_get_link_topology_nearest
+
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +311,197 @@ class TestNormalizePCIBusId:
     def test_no_match(self):
         result = _normalize_pci_bus_id("garbage")
         assert result == "garbage"
+
+
+class TestVendorLibraryLifecycle:
+    def test_nvml_query_helpers_do_not_manage_lifecycle(self, monkeypatch):
+        fake_pynvml = _make_fake_pynvml()
+        monkeypatch.setitem(sys.modules, "pynvml", fake_pynvml)
+
+        assert topology._get_pci_bus_id(0, "nvidia") == "0000:41:00.0"
+        assert topology._get_gpu_uuid(0, "nvidia", pci_bus_id="0000:41:00.0") == "uuid-gpu0"
+        assert topology._parse_nvidia_topo(["0000:41:00.0", "0000:42:00.0"]) == [
+            [IntraNodeLinkType.SELF, IntraNodeLinkType.NVLINK],
+            [IntraNodeLinkType.NVLINK, IntraNodeLinkType.SELF],
+        ]
+        assert fake_pynvml.init_calls == 0
+        assert fake_pynvml.shutdown_calls == 0
+
+    def test_amdsmi_query_helpers_do_not_manage_lifecycle(self, monkeypatch):
+        fake_amdsmi = _make_fake_amdsmi()
+        monkeypatch.setitem(sys.modules, "amdsmi", fake_amdsmi)
+
+        assert topology._get_pci_bus_id(1, "amd") == "0000:42:00.0"
+        assert topology._get_gpu_uuid(0, "amd", pci_bus_id="0000:41:00.0") == "amd-gpu0"
+        assert topology._parse_amd_topo(["0000:41:00.0", "0000:42:00.0"]) == [
+            [IntraNodeLinkType.SELF, IntraNodeLinkType.PCIE_SWITCH],
+            [IntraNodeLinkType.PCIE_SWITCH, IntraNodeLinkType.SELF],
+        ]
+        assert fake_amdsmi.init_calls == 0
+        assert fake_amdsmi.shutdown_calls == 0
+
+    def test_nvml_outer_helpers_initialize_and_shutdown(self, monkeypatch):
+        fake_pynvml = _make_fake_pynvml()
+        monkeypatch.setitem(sys.modules, "pynvml", fake_pynvml)
+
+        topology._outer_init_vendor_lib("nvidia")
+        topology._outer_shutdown_vendor_lib("nvidia")
+
+        assert fake_pynvml.init_calls == 1
+        assert fake_pynvml.shutdown_calls == 1
+
+    def test_amdsmi_outer_helpers_initialize_and_shutdown(self, monkeypatch):
+        fake_amdsmi = _make_fake_amdsmi()
+        monkeypatch.setitem(sys.modules, "amdsmi", fake_amdsmi)
+
+        topology._outer_init_vendor_lib("amd")
+        topology._outer_shutdown_vendor_lib("amd")
+
+        assert fake_amdsmi.init_calls == 1
+        assert fake_amdsmi.shutdown_calls == 1
+
+    def test_get_gpu_fabric_info_uses_existing_vendor_lifecycle(self, monkeypatch):
+        fake_pynvml = _make_fake_pynvml()
+        monkeypatch.setitem(sys.modules, "pynvml", fake_pynvml)
+
+        fabric = topology._get_gpu_fabric_info(0, "nvidia", pci_bus_id="0000:41:00.0")
+
+        assert fabric.domain_key == f"{'01' * 16}:7"
+        assert fake_pynvml.init_calls == 0
+        assert fake_pynvml.shutdown_calls == 0
+
+    def test_missing_library_fallbacks_preserve_logs(self, monkeypatch, caplog):
+        caplog.set_level(logging.DEBUG, logger="iris.topology")
+        real_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name in {"pynvml", "amdsmi"}:
+                raise ImportError(f"{name} unavailable")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        assert topology._get_pci_bus_id(0, "nvidia") == "unknown"
+        assert any(record.message == "pynvml not available" for record in caplog.records)
+
+        caplog.clear()
+        assert topology._parse_amd_topo(["0000:41:00.0"]) is None
+        assert any(record.message == "amdsmi not available for topology query" for record in caplog.records)
+
+    def test_discover_uses_outer_vendor_lifecycle(self, monkeypatch):
+        lifecycle_calls = []
+
+        monkeypatch.setattr(topology, "_detect_vendor", lambda: "nvidia")
+        monkeypatch.setattr(socket, "gethostname", lambda: "test-host")
+        monkeypatch.setattr(torch.cuda, "get_device_name", lambda gpu_id: "Fake GPU")
+        monkeypatch.setattr(topology, "_get_total_memory_mb", lambda gpu_id: 81920)
+        monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+        monkeypatch.setattr(topology, "_get_pci_bus_id", lambda gpu_id, vendor: f"0000:4{gpu_id + 1}:00.0")
+        monkeypatch.setattr(topology, "_get_gpu_uuid", lambda gpu_id, vendor, pci_bus_id="": f"uuid-{gpu_id}")
+        monkeypatch.setattr(topology, "_get_numa_node", lambda pci_bus_id: 0)
+        monkeypatch.setattr(topology, "_detect_infiniband", lambda: (False, []))
+        monkeypatch.setattr(topology, "_all_gather_strings", lambda payload, world_size: [payload])
+        monkeypatch.setattr(
+            topology,
+            "_detect_intra_node_topology",
+            lambda pci_bus_ids, vendor: (
+                [
+                    [IntraNodeLinkType.SELF, IntraNodeLinkType.NVLINK],
+                    [IntraNodeLinkType.NVLINK, IntraNodeLinkType.SELF],
+                ],
+                [[True, True], [True, True]],
+            ),
+        )
+        monkeypatch.setattr(
+            topology,
+            "_outer_init_vendor_lib",
+            lambda vendor: lifecycle_calls.append(("init", vendor)),
+        )
+        monkeypatch.setattr(
+            topology,
+            "_outer_shutdown_vendor_lib",
+            lambda vendor: lifecycle_calls.append(("shutdown", vendor)),
+        )
+        monkeypatch.setattr(
+            topology,
+            "_get_gpu_fabric_info",
+            lambda gpu_id, vendor, pci_bus_id="": FabricInfo(cluster_uuid="feedbeef", clique_id=3),
+        )
+
+        discovery = TopologyDiscovery.__new__(TopologyDiscovery)
+        discovery.rank = 0
+        discovery.world_size = 1
+        discovery.gpu_id = 0
+        discovery._topology = None
+
+        topo = discovery.discover()
+
+        assert lifecycle_calls == [("init", "nvidia"), ("shutdown", "nvidia")]
+        assert isinstance(topo, TopologyMap)
+        assert topo.gpu_info[0].pci_bus_id == "0000:41:00.0"
+        assert topo.gpu_info[0].uuid == "uuid-0"
+        assert topo.gpu_info[0].fabric_info.domain_key == "feedbeef:3"
+        assert topo.nodes["test-host"].link_types[0][1] == IntraNodeLinkType.NVLINK
+
+    def test_discover_shuts_down_outer_vendor_lifecycle_on_exception(self, monkeypatch):
+        lifecycle_calls = []
+
+        monkeypatch.setattr(topology, "_detect_vendor", lambda: "nvidia")
+        monkeypatch.setattr(socket, "gethostname", lambda: "test-host")
+        monkeypatch.setattr(
+            topology,
+            "_outer_init_vendor_lib",
+            lambda vendor: lifecycle_calls.append(("init", vendor)),
+        )
+        monkeypatch.setattr(
+            topology,
+            "_outer_shutdown_vendor_lib",
+            lambda vendor: lifecycle_calls.append(("shutdown", vendor)),
+        )
+        monkeypatch.setattr(torch.cuda, "get_device_name", lambda gpu_id: "Fake GPU")
+        monkeypatch.setattr(topology, "_get_total_memory_mb", lambda gpu_id: 81920)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(topology, "_get_pci_bus_id", boom)
+
+        discovery = TopologyDiscovery.__new__(TopologyDiscovery)
+        discovery.rank = 0
+        discovery.world_size = 1
+        discovery.gpu_id = 0
+        discovery._topology = None
+
+        with pytest.raises(RuntimeError, match="boom"):
+            discovery.discover()
+
+        assert lifecycle_calls == [("init", "nvidia"), ("shutdown", "nvidia")]
+
+    def test_discover_unknown_vendor_uses_noop_outer_lifecycle(self, monkeypatch):
+        monkeypatch.setattr(topology, "_detect_vendor", lambda: "unknown")
+        monkeypatch.setattr(socket, "gethostname", lambda: "test-host")
+        monkeypatch.setattr(torch.cuda, "get_device_name", lambda gpu_id: "CPU-only fallback")
+        monkeypatch.setattr(topology, "_get_total_memory_mb", lambda gpu_id: 0)
+        monkeypatch.setattr(topology, "_get_pci_bus_id", lambda gpu_id, vendor: "unknown")
+        monkeypatch.setattr(topology, "_get_gpu_uuid", lambda gpu_id, vendor, pci_bus_id="": "gpu-test-host-0")
+        monkeypatch.setattr(topology, "_get_numa_node", lambda pci_bus_id: -1)
+        monkeypatch.setattr(topology, "_get_gpu_fabric_info", lambda gpu_id, vendor, pci_bus_id="": FabricInfo())
+        monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+        monkeypatch.setattr(topology, "_detect_infiniband", lambda: (False, []))
+        monkeypatch.setattr(topology, "_detect_intra_node_topology", lambda pci_bus_ids, vendor: (None, None))
+        monkeypatch.setattr(topology, "_all_gather_strings", lambda payload, world_size: [payload])
+
+        discovery = TopologyDiscovery.__new__(TopologyDiscovery)
+        discovery.rank = 0
+        discovery.world_size = 1
+        discovery.gpu_id = 0
+        discovery._topology = None
+
+        topo = discovery.discover()
+
+        assert isinstance(topo, TopologyMap)
+        assert topo.gpu_info[0].vendor == "unknown"
+        assert topo.gpu_info[0].fabric_info == FabricInfo()
+        assert topo.nodes["test-host"].num_gpus == 1
 
 
 class TestNodeInfo:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Currently, **every helper function that touches the vendor library performs its own `init()` + `shutdown()` pair** inside a `try/finally` block. During a single topology discovery this performs very poorly. Now it's calling these functions once lazily when required.

Also improving device_utils.py because unit tests that require no GPU fail when they are running on a machine with no supported AMD GPU as extra.hip package is only available on systems with AMD GPUs. 

## Test Plan

```
python -m pytest tests/unittests/test_topology.py -v
```

## Test Result

```
tests/unittests/test_topology.py::TestFabricInfo::test_empty_fabric_info PASSED                                                         [  1%]
tests/unittests/test_topology.py::TestFabricInfo::test_valid_fabric_info PASSED                                                         [  2%]
tests/unittests/test_topology.py::TestFabricInfo::test_domain_key_comparison PASSED                                                     [  3%]
tests/unittests/test_topology.py::TestFabricInfo::test_empty_domain_keys_do_not_match PASSED                                            [  5%]
tests/unittests/test_topology.py::TestFabricInfo::test_serialization_roundtrip PASSED                                                   [  6%]
tests/unittests/test_topology.py::TestFabricInfo::test_from_dict_missing_keys PASSED                                                    [  7%]
tests/unittests/test_topology.py::TestGPUInfo::test_serialization_roundtrip PASSED                                                      [  8%]
tests/unittests/test_topology.py::TestGPUInfo::test_from_dict_does_not_mutate_input PASSED                                              [ 10%]
tests/unittests/test_topology.py::TestGPUInfo::test_from_dict_missing_fabric PASSED                                                     [ 11%]
tests/unittests/test_topology.py::TestNormalizePCIBusId::test_standard_format PASSED                                                    [ 12%]
tests/unittests/test_topology.py::TestNormalizePCIBusId::test_uppercase PASSED                                                          [ 13%]
tests/unittests/test_topology.py::TestNormalizePCIBusId::test_nvidia_8char_domain PASSED                                                [ 15%]
tests/unittests/test_topology.py::TestNormalizePCIBusId::test_prefix_junk PASSED                                                        [ 16%]
tests/unittests/test_topology.py::TestNormalizePCIBusId::test_no_match PASSED                                                           [ 17%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_nvml_query_helpers_do_not_manage_lifecycle PASSED                    [ 18%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_amdsmi_query_helpers_do_not_manage_lifecycle PASSED                  [ 20%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_nvml_outer_helpers_initialize_and_shutdown PASSED                    [ 21%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_amdsmi_outer_helpers_initialize_and_shutdown PASSED                  [ 22%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_get_gpu_fabric_info_initializes_and_shuts_down_standalone PASSED     [ 23%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_missing_library_fallbacks_preserve_logs PASSED                       [ 25%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_discover_uses_outer_vendor_lifecycle PASSED                          [ 26%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_discover_shuts_down_outer_vendor_lifecycle_on_exception PASSED       [ 27%]
tests/unittests/test_topology.py::TestVendorLibraryLifecycle::test_discover_unknown_vendor_uses_noop_outer_lifecycle PASSED             [ 28%]
tests/unittests/test_topology.py::TestNodeInfo::test_get_link_type_self PASSED                                                          [ 30%]
tests/unittests/test_topology.py::TestNodeInfo::test_get_link_type_out_of_bounds PASSED                                                 [ 31%]
tests/unittests/test_topology.py::TestNodeInfo::test_get_link_type_no_matrix PASSED                                                     [ 32%]
tests/unittests/test_topology.py::TestNodeInfo::test_p2p_access_out_of_bounds PASSED                                                    [ 33%]
tests/unittests/test_topology.py::TestNodeInfo::test_p2p_access_self_always_true PASSED                                                 [ 35%]
tests/unittests/test_topology.py::TestTopologyMap::test_same_rank_is_intra_node PASSED                                                  [ 36%]
tests/unittests/test_topology.py::TestTopologyMap::test_same_node_is_intra_node PASSED                                                  [ 37%]
tests/unittests/test_topology.py::TestTopologyMap::test_same_fabric_different_node_is_fabric PASSED                                     [ 38%]
tests/unittests/test_topology.py::TestTopologyMap::test_no_fabric_is_rdma PASSED                                                        [ 40%]
tests/unittests/test_topology.py::TestTopologyMap::test_node_peers PASSED                                                               [ 41%]
tests/unittests/test_topology.py::TestTopologyMap::test_fabric_domain_peers PASSED                                                      [ 42%]
tests/unittests/test_topology.py::TestTopologyMap::test_rdma_peers PASSED                                                               [ 43%]
tests/unittests/test_topology.py::TestTopologyMap::test_peer_groups_partition_world PASSED                                              [ 45%]
tests/unittests/test_topology.py::TestTopologyMap::test_comm_groups_intra_node PASSED                                                   [ 46%]
tests/unittests/test_topology.py::TestTopologyMap::test_comm_groups_fabric_includes_standalone PASSED                                   [ 47%]
tests/unittests/test_topology.py::TestTopologyMap::test_comm_groups_fabric_domain_group_content PASSED                                  [ 48%]
tests/unittests/test_topology.py::TestTopologyMap::test_comm_groups_fabric_is_not_empty_when_domains_exist PASSED                       [ 50%]
tests/unittests/test_topology.py::TestTopologyMap::test_comm_groups_rdma_is_world PASSED                                                [ 51%]
tests/unittests/test_topology.py::TestTopologyMap::test_heap_plan_completeness PASSED                                                   [ 52%]
tests/unittests/test_topology.py::TestTopologyMap::test_heap_plan_rank4 PASSED                                                          [ 53%]
tests/unittests/test_topology.py::TestTopologyMap::test_heap_plan_no_peer_overlap PASSED                                                [ 55%]
tests/unittests/test_topology.py::TestTopologyMap::test_summary_contains_all_nodes PASSED                                               [ 56%]
tests/unittests/test_topology.py::TestTopologyMap::test_ranks_for_fabric_domain PASSED                                                  [ 57%]
tests/unittests/test_topology.py::TestTopologyMap::test_ranks_for_nonexistent_domain PASSED                                             [ 58%]
tests/unittests/test_topology.py::TestOversubscription::test_num_gpus_is_physical_count PASSED                                          [ 60%]
tests/unittests/test_topology.py::TestOversubscription::test_link_type_by_gpu_id PASSED                                                 [ 61%]
tests/unittests/test_topology.py::TestOversubscription::test_p2p_by_gpu_id PASSED                                                       [ 62%]
tests/unittests/test_topology.py::TestOversubscription::test_all_ranks_are_node_peers PASSED                                            [ 63%]
tests/unittests/test_topology.py::TestIsolationCollapse::test_num_gpus_not_collapsed PASSED                                             [ 65%]
tests/unittests/test_topology.py::TestIsolationCollapse::test_both_ranks_are_node_peers PASSED                                          [ 66%]
tests/unittests/test_topology.py::TestNoFabricCluster::test_no_fabric_all_rdma PASSED                                                   [ 67%]
tests/unittests/test_topology.py::TestNoFabricCluster::test_fabric_peers_empty PASSED                                                   [ 68%]
tests/unittests/test_topology.py::TestNoFabricCluster::test_comm_groups_no_fabric_is_empty PASSED                                       [ 70%]
tests/unittests/test_topology.py::TestNoFabricCluster::test_comm_groups_intra_node_still_correct PASSED                                 [ 71%]
tests/unittests/test_topology.py::TestNoFabricCluster::test_comm_groups_rdma_still_covers_world PASSED                                  [ 72%]
tests/unittests/test_topology.py::TestNoFabricCluster::test_heap_plan_no_fabric_peers PASSED                                            [ 73%]
tests/unittests/test_topology.py::TestAllFabricCluster::test_comm_groups_fabric_spans_nodes PASSED                                      [ 75%]
tests/unittests/test_topology.py::TestAllFabricCluster::test_comm_groups_no_standalone_groups PASSED                                    [ 76%]
tests/unittests/test_topology.py::TestAllFabricCluster::test_comm_groups_intra_node_still_per_host PASSED                               [ 77%]
tests/unittests/test_topology.py::TestAllFabricCluster::test_heap_plan_fabric_peers_cross_node PASSED                                   [ 78%]
tests/unittests/test_topology.py::TestAllFabricCluster::test_interconnect_cross_node_is_fabric PASSED                                   [ 80%]
tests/unittests/test_topology.py::TestDistributed::test_all_gather_strings SKIPPED (No distributed process group)                       [ 81%]
tests/unittests/test_topology.py::TestDistributed::test_all_gather_strings_empty SKIPPED (No distributed process group)                 [ 82%]
tests/unittests/test_topology.py::TestDistributed::test_all_gather_strings_large_payload SKIPPED (No distributed process group)         [ 83%]
tests/unittests/test_topology.py::TestFullDiscovery::test_discover_returns_topology SKIPPED (No distributed process group)              [ 85%]
tests/unittests/test_topology.py::TestFullDiscovery::test_local_rank_is_unique_per_node SKIPPED (No distributed process group)          [ 86%]
tests/unittests/test_topology.py::TestFullDiscovery::test_own_rank_info_correct SKIPPED (No distributed process group)                  [ 87%]
tests/unittests/test_topology.py::TestFullDiscovery::test_interconnect_symmetry SKIPPED (No distributed process group)                  [ 88%]
tests/unittests/test_topology.py::TestFullDiscovery::test_peer_partition_exhaustive SKIPPED (No distributed process group)              [ 90%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_no_env_var_returns_logical PASSED                                 [ 91%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_nvidia_remapping PASSED                                           [ 92%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_amd_hip_visible PASSED                                            [ 93%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_amd_rocr_fallback PASSED                                          [ 95%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_hip_takes_priority_over_rocr PASSED                               [ 96%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_logical_out_of_range_returns_logical PASSED                       [ 97%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_uuid_style_entry_returns_logical PASSED                           [ 98%]
tests/unittests/test_topology.py::TestLogicalToPhysicalGpuIndex::test_negative_index_passthrough PASSED                                 [100%]

======================================================== 72 passed, 8 skipped in 0.87s ========================================================
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
