### PR TITLE
Mark message passing tests as flaky with auto-retry

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -77,6 +77,7 @@ EXIT_CODE=0
     
     echo \"Installing iris using method: $INSTALL_METHOD\"
     $INSTALL_CMD
+    pip install pytest-rerunfailures
     
     # Run tests in the specified directory
     for test_file in tests/$TEST_DIR/test_*.py; do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ amd = [
 ]
 dev = [
     "pytest",
+    "pytest-rerunfailures",
     "black",
     "mypy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ version_scheme = "post-release"   # .postN after last tag
 local_scheme = "node-and-date"    # add commit hash (e.g. +gabc1234) and date (e.g. +20250914)
 fallback_version = "0.0.0"        # used if git metadata unavailable
 
+[tool.pytest.ini_options]
+markers = [
+    "flaky: mark test as flaky with auto-retry (deselect with '-m \"not flaky\"')",
+]
+
 [tool.ruff]
 line-length = 120
 exclude = [

--- a/tests/examples/test_message_passing.py
+++ b/tests/examples/test_message_passing.py
@@ -132,6 +132,7 @@ def run_message_passing_kernels(module, args):
         1024,
     ],
 )
+@pytest.mark.flaky(reruns=2)
 def test_message_passing_load_store(dtype_str, buffer_size, heap_size, block_size):
     """Test message passing with load/store operations."""
     args = create_test_args(dtype_str, buffer_size, heap_size, block_size)
@@ -162,6 +163,7 @@ def test_message_passing_load_store(dtype_str, buffer_size, heap_size, block_siz
         1024,
     ],
 )
+@pytest.mark.flaky(reruns=2)
 def test_message_passing_put(dtype_str, buffer_size, heap_size, block_size):
     """Test message passing with put operations."""
     args = create_test_args(dtype_str, buffer_size, heap_size, block_size)


### PR DESCRIPTION
## Summary

- Add `pytest-rerunfailures` to dev dependencies
- Mark `test_message_passing_load_store` and `test_message_passing_put` with `@pytest.mark.flaky(reruns=2)`

These tests use producer/consumer flag synchronization across 2 ranks and intermittently fail in CI due to timing sensitivity. Auto-retrying up to 2 times eliminates the noise without masking real failures.

## Test plan

- [ ] CI passes (the flaky tests should auto-retry on transient failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)