### PR TITLE
Increase nightly docker build timeout to 150 minutes

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 90
+    timeout-minutes: 150
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Increase `timeout-minutes` from 90 to 150 in the nightly Docker build workflow.

## Problem
The nightly Docker build has been failing since ~June 6 (34 consecutive failures). The build compiles Triton from source, which takes 45-60+ minutes on `ubuntu-latest` runners. Combined with Docker base image pull + apt install + pip setup, total job time is consistently ~95 minutes — exceeding the 90 minute timeout.

All recent runs end with:
```
##[error]The runner has received a shutdown signal.
##[error]Process completed with exit code 143.
```

Last successful run: May 22 (run #49).

## Fix
One-line change: `timeout-minutes: 90` → `timeout-minutes: 150`. Provides sufficient headroom for the full Triton source build.