### PR TITLE
Add AMD Fabric driver and support AMD fabric in topology discovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # These users will be automatically requested for review when changes are made
 
 # Global code owners for the entire repository
-* @mawad-amd @neoblizz @BKP
+* @mawad-amd @neoblizz @BKP @artulab

--- a/iris/drivers/fabric/amd.py
+++ b/iris/drivers/fabric/amd.py
@@ -2,42 +2,706 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 """
-AMD fabric driver stub.
+AMD HIP VMM fabric driver.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+import ctypes
+import ctypes.util
+import logging
+import re
+from collections.abc import Callable
+from typing import Any, Optional
+
+import torch
 
 from iris.drivers.base import (
     BaseDriver,
+    DriverError,
     DriverNotSupported,
     ExportableMemory,
     LocalAllocation,
     MappingPlacement,
     PeerMapping,
 )
+from iris.host.distributed.topology import InterconnectLevel
 
-__all__ = ["AmdFabricDriver"]
+logger = logging.getLogger("iris.drivers.fabric.amd")
 
-_NOT_IMPLEMENTED_MESSAGE = "AMD fabric driver not yet implemented"
+__all__ = [
+    "AmdFabricError",
+    "AmdFabricNotSupported",
+    "AMD_FABRIC_HANDLE_BYTES",
+    "FABRIC_HANDLE_BYTES",
+    "AmdFabricDriver",
+]
+
+
+def _load_cdll(*names: Optional[str]) -> Any:
+    for name in names:
+        if not name:
+            continue
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    return None
+
+
+_hip = _load_cdll(
+    ctypes.util.find_library("amdhip64"),
+    "libamdhip64.so",
+    "/opt/rocm/lib/libamdhip64.so",
+)
+_amdsmi = _load_cdll(
+    ctypes.util.find_library("amd_smi"),
+    "libamd_smi.so",
+    "/opt/rocm/lib/libamd_smi.so",
+)
+
+HIP_SUCCESS = 0
+HIP_ERROR_NOT_SUPPORTED = 801
+
+AMDSMI_STATUS_SUCCESS = 0
+AMDSMI_STATUS_NOT_SUPPORTED = 2
+AMDSMI_STATUS_NOT_YET_IMPLEMENTED = 3
+AMDSMI_STATUS_NO_DATA = 40
+AMDSMI_INIT_AMD_GPUS = 1 << 1
+
+FABRIC_HANDLE_BYTES = 64
+AMD_FABRIC_HANDLE_BYTES = FABRIC_HANDLE_BYTES
+
+_UINT32_MAX = 0xFFFFFFFF
+_AMDSMI_FABRIC_PPOD_SENTINEL = bytes([0x99] * 16)
+_PCI_BUS_ID_BYTES = 256
+
+hipMemAllocationTypePinned = 0x1
+hipMemHandleTypeFabric = 0x8
+hipMemLocationTypeDevice = 0x1
+hipMemAllocationGranularityRecommended = 0x1
+hipMemAccessFlagsProtReadWrite = 0x3
+
+hipMemGenericAllocationHandle_t = ctypes.c_void_p
+amdsmi_processor_handle = ctypes.c_void_p
+amdsmi_status_t = ctypes.c_uint32
+
+
+class AmdFabricError(DriverError):
+    """AMD HIP/AMDSMI fabric operation failed."""
+
+
+class AmdFabricNotSupported(DriverNotSupported):
+    """The local AMD stack does not support fabric handles."""
+
+
+class hipMemLocation(ctypes.Structure):
+    """Structure describing a HIP memory location."""
+
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("id", ctypes.c_int),
+    ]
+
+
+class _hipMemAllocationHandleTypes(ctypes.Union):
+    _fields_ = [
+        ("requestedHandleType", ctypes.c_int),
+        ("requestedHandleTypes", ctypes.c_int),
+    ]
+
+
+class _hipMemAllocationFlags(ctypes.Structure):
+    _fields_ = [
+        ("compressionType", ctypes.c_ubyte),
+        ("gpuDirectRDMACapable", ctypes.c_ubyte),
+        ("usage", ctypes.c_ushort),
+    ]
+
+
+class hipMemAllocationProp(ctypes.Structure):
+    """Properties for a HIP VMem allocation."""
+
+    _anonymous_ = ("handleTypes",)
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("handleTypes", _hipMemAllocationHandleTypes),
+        ("location", hipMemLocation),
+        ("win32HandleMetaData", ctypes.c_void_p),
+        ("allocFlags", _hipMemAllocationFlags),
+    ]
+
+
+class hipMemAccessDesc(ctypes.Structure):
+    """Access descriptor for a HIP VMem mapping."""
+
+    _fields_ = [
+        ("location", hipMemLocation),
+        ("flags", ctypes.c_int),
+    ]
+
+
+class hipMemFabricHandle(ctypes.Structure):
+    """HIP fabric handle. ROCm defines this with HIP_IPC_HANDLE_SIZE bytes."""
+
+    _fields_ = [("data", ctypes.c_ubyte * FABRIC_HANDLE_BYTES)]
+
+
+class _amdsmi_bdf_bitfields(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("function_number", ctypes.c_uint64, 3),
+        ("device_number", ctypes.c_uint64, 5),
+        ("bus_number", ctypes.c_uint64, 8),
+        ("domain_number", ctypes.c_uint64, 48),
+    ]
+
+
+class amdsmi_bdf_t(ctypes.Union):
+    _pack_ = 1
+    _fields_ = [
+        ("bdf", _amdsmi_bdf_bitfields),
+        ("as_uint", ctypes.c_uint64),
+    ]
+
+
+class amdsmi_fabric_info_v1_t(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("accelerator_id", ctypes.c_uint32),
+        ("fabric_type", ctypes.c_uint32),
+        ("bandwidth", ctypes.c_uint32),
+        ("latency", ctypes.c_uint32),
+        ("ppod_id", ctypes.c_ubyte * 16),
+        ("ppod_size", ctypes.c_uint32),
+        ("vpod_id", ctypes.c_uint32),
+        ("vpod_size", ctypes.c_uint32),
+        ("vpod_active_accelerators", ctypes.c_uint32 * 32),
+        ("local_accelerators", ctypes.c_uint32 * 16),
+        ("addr_mode", ctypes.c_uint32),
+        ("accel_state", ctypes.c_uint32),
+    ]
+
+
+class _amdsmi_fabric_info_union(ctypes.Union):
+    _pack_ = 1
+    _fields_ = [("v1", amdsmi_fabric_info_v1_t)]
+
+
+class amdsmi_fabric_info_ver_t(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("version", ctypes.c_uint32),
+        ("fabric_version", _amdsmi_fabric_info_union),
+    ]
+
+
+class amdsmi_fabric_info_t(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("bdf", amdsmi_bdf_t),
+        ("fabric_info", amdsmi_fabric_info_ver_t),
+        ("reserved", ctypes.c_uint32 * 15),
+        ("_padding", ctypes.c_ubyte * 4),
+    ]
+
+
+def _get_required_hip_symbol(name: str) -> Any:
+    if _hip is None:
+        raise AmdFabricNotSupported("libamdhip64.so not found")
+
+    symbol = getattr(_hip, name, None)
+    if symbol is None:
+        raise AmdFabricNotSupported(f"HIP runtime missing required symbol: {name}")
+    return symbol
+
+
+def _get_required_amdsmi_symbol(name: str) -> Any:
+    if _amdsmi is None:
+        raise AmdFabricNotSupported("libamd_smi.so not found")
+
+    symbol = getattr(_amdsmi, name, None)
+    if symbol is None:
+        raise AmdFabricNotSupported(f"AMDSMI library missing required symbol: {name}")
+    return symbol
+
+
+def _configure_signatures() -> None:
+    """Configure ctypes signatures for all HIP and AMDSMI functions used here."""
+    if _hip is None:
+        return
+
+    hip_set_device = _get_required_hip_symbol("hipSetDevice")
+    hip_device_get_pci_bus_id = _get_required_hip_symbol("hipDeviceGetPCIBusId")
+    hip_mem_get_allocation_granularity = _get_required_hip_symbol("hipMemGetAllocationGranularity")
+    hip_mem_create = _get_required_hip_symbol("hipMemCreate")
+    hip_mem_address_reserve = _get_required_hip_symbol("hipMemAddressReserve")
+    hip_mem_map = _get_required_hip_symbol("hipMemMap")
+    hip_mem_set_access = _get_required_hip_symbol("hipMemSetAccess")
+    hip_mem_unmap = _get_required_hip_symbol("hipMemUnmap")
+    hip_mem_release = _get_required_hip_symbol("hipMemRelease")
+    hip_mem_address_free = _get_required_hip_symbol("hipMemAddressFree")
+    hip_mem_export_to_shareable_handle = _get_required_hip_symbol("hipMemExportToShareableHandle")
+    hip_mem_import_from_shareable_handle = _get_required_hip_symbol("hipMemImportFromShareableHandle")
+    hip_get_error_string = _get_required_hip_symbol("hipGetErrorString")
+
+    hip_set_device.argtypes = [ctypes.c_int]
+    hip_set_device.restype = ctypes.c_int
+
+    hip_device_get_pci_bus_id.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_int,
+    ]
+    hip_device_get_pci_bus_id.restype = ctypes.c_int
+
+    hip_mem_get_allocation_granularity.argtypes = [
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(hipMemAllocationProp),
+        ctypes.c_int,
+    ]
+    hip_mem_get_allocation_granularity.restype = ctypes.c_int
+
+    hip_mem_create.argtypes = [
+        ctypes.POINTER(hipMemGenericAllocationHandle_t),
+        ctypes.c_size_t,
+        ctypes.POINTER(hipMemAllocationProp),
+        ctypes.c_ulonglong,
+    ]
+    hip_mem_create.restype = ctypes.c_int
+
+    hip_mem_address_reserve.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_size_t,
+        ctypes.c_size_t,
+        ctypes.c_void_p,
+        ctypes.c_ulonglong,
+    ]
+    hip_mem_address_reserve.restype = ctypes.c_int
+
+    hip_mem_map.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_size_t,
+        hipMemGenericAllocationHandle_t,
+        ctypes.c_ulonglong,
+    ]
+    hip_mem_map.restype = ctypes.c_int
+
+    hip_mem_set_access.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(hipMemAccessDesc),
+        ctypes.c_size_t,
+    ]
+    hip_mem_set_access.restype = ctypes.c_int
+
+    hip_mem_unmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    hip_mem_unmap.restype = ctypes.c_int
+
+    hip_mem_release.argtypes = [hipMemGenericAllocationHandle_t]
+    hip_mem_release.restype = ctypes.c_int
+
+    hip_mem_address_free.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    hip_mem_address_free.restype = ctypes.c_int
+
+    hip_mem_export_to_shareable_handle.argtypes = [
+        ctypes.c_void_p,
+        hipMemGenericAllocationHandle_t,
+        ctypes.c_int,
+        ctypes.c_ulonglong,
+    ]
+    hip_mem_export_to_shareable_handle.restype = ctypes.c_int
+
+    hip_mem_import_from_shareable_handle.argtypes = [
+        ctypes.POINTER(hipMemGenericAllocationHandle_t),
+        ctypes.c_void_p,
+        ctypes.c_int,
+    ]
+    hip_mem_import_from_shareable_handle.restype = ctypes.c_int
+
+    hip_get_error_string.argtypes = [ctypes.c_int]
+    hip_get_error_string.restype = ctypes.c_char_p
+
+    if _amdsmi is None:
+        return
+
+    amdsmi_init = _get_required_amdsmi_symbol("amdsmi_init")
+    amdsmi_get_processor_handle_from_bdf = _get_required_amdsmi_symbol("amdsmi_get_processor_handle_from_bdf")
+    amdsmi_get_gpu_fabric_info = _get_required_amdsmi_symbol("amdsmi_get_gpu_fabric_info")
+
+    amdsmi_init.argtypes = [ctypes.c_uint64]
+    amdsmi_init.restype = amdsmi_status_t
+
+    amdsmi_get_processor_handle_from_bdf.argtypes = [
+        amdsmi_bdf_t,
+        ctypes.POINTER(amdsmi_processor_handle),
+    ]
+    amdsmi_get_processor_handle_from_bdf.restype = amdsmi_status_t
+
+    amdsmi_get_gpu_fabric_info.argtypes = [
+        amdsmi_processor_handle,
+        ctypes.POINTER(amdsmi_fabric_info_t),
+    ]
+    amdsmi_get_gpu_fabric_info.restype = amdsmi_status_t
+
+    amdsmi_status_code_to_string = getattr(_amdsmi, "amdsmi_status_code_to_string", None)
+    if amdsmi_status_code_to_string is not None:
+        amdsmi_status_code_to_string.argtypes = [
+            amdsmi_status_t,
+            ctypes.POINTER(ctypes.c_char_p),
+        ]
+        amdsmi_status_code_to_string.restype = amdsmi_status_t
+
+
+def _hip_try(err: int, op_name: str = "HIP operation") -> None:
+    """Check a HIP runtime return code and raise a driver exception on error."""
+    if err == HIP_SUCCESS:
+        return
+
+    error_string = str(err)
+    if _hip is not None and hasattr(_hip, "hipGetErrorString"):
+        decoded = _hip.hipGetErrorString(ctypes.c_int(err))
+        if decoded:
+            error_string = decoded.decode("utf-8", errors="replace")
+
+    message = f"{op_name} failed with HIP error code {err}: {error_string}"
+    if err == HIP_ERROR_NOT_SUPPORTED:
+        raise AmdFabricNotSupported(message)
+    raise AmdFabricError(message)
+
+
+def _amdsmi_status_string(err: int) -> str:
+    if _amdsmi is not None and hasattr(_amdsmi, "amdsmi_status_code_to_string"):
+        ptr = ctypes.c_char_p()
+        ret = _amdsmi.amdsmi_status_code_to_string(amdsmi_status_t(err), ctypes.byref(ptr))
+        if ret == AMDSMI_STATUS_SUCCESS and ptr.value:
+            return ptr.value.decode("utf-8", errors="replace")
+    return str(err)
+
+
+def _amdsmi_try(err: int, op_name: str = "AMDSMI operation") -> None:
+    """Check an AMDSMI return code and raise a driver exception on error."""
+    if err == AMDSMI_STATUS_SUCCESS:
+        return
+
+    message = f"{op_name} failed with AMDSMI status {err}: {_amdsmi_status_string(err)}"
+    if err in (AMDSMI_STATUS_NOT_SUPPORTED, AMDSMI_STATUS_NOT_YET_IMPLEMENTED, AMDSMI_STATUS_NO_DATA):
+        raise AmdFabricNotSupported(message)
+    raise AmdFabricError(message)
+
+
+def _round_up(value: int, granularity: int) -> int:
+    if granularity <= 0:
+        raise ValueError(f"granularity must be > 0, got {granularity}")
+    return ((value + granularity - 1) // granularity) * granularity
+
+
+def _normalize_fabric_handle_bytes(raw_handle: Any) -> bytes:
+    if isinstance(raw_handle, memoryview):
+        data = raw_handle.tobytes()
+    elif isinstance(raw_handle, (bytes, bytearray)):
+        data = bytes(raw_handle)
+    elif isinstance(raw_handle, torch.Tensor):
+        data = bytes(raw_handle.detach().to("cpu", copy=True).flatten().tolist())
+    else:
+        try:
+            data = bytes(raw_handle)
+        except Exception:
+            try:
+                data = ctypes.string_at(ctypes.addressof(raw_handle), FABRIC_HANDLE_BYTES)
+            except Exception as exc:
+                raise AmdFabricError("Unable to convert fabric handle object to bytes") from exc
+
+    if len(data) != FABRIC_HANDLE_BYTES:
+        raise AmdFabricError(f"Fabric handle serialization expected {FABRIC_HANDLE_BYTES} bytes, got {len(data)}")
+    return data
+
+
+def _run_cleanup_steps(*steps: tuple[str, Callable[[], None]]) -> None:
+    first_error = None
+    for name, step in steps:
+        try:
+            step()
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+            else:
+                logger.warning("Secondary cleanup step %s failed: %s", name, exc)
+    if first_error is not None:
+        raise first_error
+
+
+def _cleanup_after_failure(*steps: tuple[str, Callable[[], None]]) -> None:
+    for name, step in steps:
+        try:
+            step()
+        except Exception as exc:
+            logger.warning("Cleanup step %s failed after earlier failure: %s", name, exc)
+
+
+_PCI_BDF_RE = re.compile(r"([0-9a-fA-F]+):([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-7])")
+
+
+def _amdsmi_bdf_from_pci_bus_id(pci_bus_id: str) -> amdsmi_bdf_t:
+    match = _PCI_BDF_RE.search(pci_bus_id.strip())
+    if match is None:
+        raise AmdFabricError(f"Unable to parse HIP PCI bus ID: {pci_bus_id!r}")
+
+    domain = int(match.group(1), 16)
+    bus = int(match.group(2), 16)
+    device = int(match.group(3), 16)
+    function = int(match.group(4), 16)
+
+    bdf = amdsmi_bdf_t()
+    bdf.as_uint = (domain << 16) | (bus << 8) | (device << 3) | function
+    return bdf
+
+
+def _valid_fabric_domain(ppod_id: bytes, vpod_id: int) -> bool:
+    if not ppod_id or ppod_id == bytes(len(ppod_id)) or ppod_id == _AMDSMI_FABRIC_PPOD_SENTINEL:
+        return False
+    return vpod_id != _UINT32_MAX
 
 
 class AmdFabricDriver(BaseDriver):
-    """AMD fabric driver placeholder."""
+    """
+    AMD HIP VMM fabric driver.
+
+    Uses HIP fabric handles for cross-host VMM export/import. Handle exchange is
+    performed by higher layers using torch.distributed collectives; this driver
+    only creates, exports, imports, maps, and releases VMM allocations.
+    """
+
+    def __init__(self) -> None:
+        self._device_ordinal: int = 0
+        self._granularity: Optional[int] = None
+        self._initialized: bool = False
+        self._fabric_domain: Optional[tuple[str, int]] = None
+
+    def _check_initialized(self) -> None:
+        if not self._initialized:
+            raise AmdFabricError("AmdFabricDriver not initialized - call initialize() first")
+
+    def _make_alloc_props(self) -> hipMemAllocationProp:
+        props = hipMemAllocationProp()
+        props.type = hipMemAllocationTypePinned
+        props.requestedHandleTypes = hipMemHandleTypeFabric
+        props.location.type = hipMemLocationTypeDevice
+        props.location.id = self._device_ordinal
+        props.win32HandleMetaData = None
+        return props
+
+    def _get_granularity(self) -> int:
+        if self._granularity is not None:
+            return self._granularity
+
+        props = self._make_alloc_props()
+        granularity = ctypes.c_size_t()
+        _hip_try(
+            _hip.hipMemGetAllocationGranularity(
+                ctypes.byref(granularity),
+                ctypes.byref(props),
+                hipMemAllocationGranularityRecommended,
+            ),
+            "hipMemGetAllocationGranularity",
+        )
+        self._granularity = int(granularity.value)
+        return self._granularity
+
+    def _mem_set_access(self, va: int, size: int) -> None:
+        desc = hipMemAccessDesc()
+        desc.location.type = hipMemLocationTypeDevice
+        desc.location.id = self._device_ordinal
+        desc.flags = hipMemAccessFlagsProtReadWrite
+        _hip_try(
+            _hip.hipMemSetAccess(ctypes.c_void_p(va), size, ctypes.byref(desc), 1),
+            "hipMemSetAccess",
+        )
+
+    def _get_device_pci_bus_id(self) -> str:
+        pci_bus_id = ctypes.create_string_buffer(_PCI_BUS_ID_BYTES)
+        _hip_try(
+            _hip.hipDeviceGetPCIBusId(pci_bus_id, _PCI_BUS_ID_BYTES, self._device_ordinal),
+            "hipDeviceGetPCIBusId",
+        )
+        return pci_bus_id.value.decode("utf-8", errors="replace")
+
+    def _query_fabric_domain(self) -> tuple[str, int]:
+        if _amdsmi is None:
+            raise AmdFabricNotSupported("libamd_smi.so not found")
+
+        _amdsmi_try(_amdsmi.amdsmi_init(AMDSMI_INIT_AMD_GPUS), "amdsmi_init")
+
+        pci_bus_id = self._get_device_pci_bus_id()
+        bdf = _amdsmi_bdf_from_pci_bus_id(pci_bus_id)
+        processor = amdsmi_processor_handle()
+        _amdsmi_try(
+            _amdsmi.amdsmi_get_processor_handle_from_bdf(bdf, ctypes.byref(processor)),
+            "amdsmi_get_processor_handle_from_bdf",
+        )
+        if processor.value is None:
+            raise AmdFabricError(f"AMDSMI returned a null processor handle for PCI bus ID {pci_bus_id}")
+
+        fabric_info = amdsmi_fabric_info_t()
+        err = int(_amdsmi.amdsmi_get_gpu_fabric_info(processor, ctypes.byref(fabric_info)))
+        if err == AMDSMI_STATUS_NO_DATA:
+            raise AmdFabricNotSupported(f"AMDSMI reported no GPU fabric data for PCI bus ID {pci_bus_id}")
+        _amdsmi_try(err, "amdsmi_get_gpu_fabric_info")
+
+        v1 = fabric_info.fabric_info.fabric_version.v1
+        ppod_id = bytes(v1.ppod_id)
+        vpod_id = int(v1.vpod_id)
+        if not _valid_fabric_domain(ppod_id, vpod_id):
+            raise AmdFabricNotSupported(
+                f"AMDSMI fabric domain is unavailable for PCI bus ID {pci_bus_id}: "
+                f"ppod_id={ppod_id.hex()} vpod_id={vpod_id}"
+            )
+
+        return ppod_id.hex(), vpod_id
 
     def initialize(self, device_ordinal: int) -> None:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Prepare HIP VMM and verify that the selected GPU has fabric data."""
+        if _hip is None:
+            raise AmdFabricNotSupported("libamdhip64.so not found")
+        if _amdsmi is None:
+            raise AmdFabricNotSupported("libamd_smi.so not found")
+
+        _configure_signatures()
+        _hip_try(_hip.hipSetDevice(device_ordinal), "hipSetDevice")
+        self._device_ordinal = device_ordinal
+        self._granularity = None
+        self._fabric_domain = self._query_fabric_domain()
+        self._initialized = True
+        logger.info(
+            "AmdFabricDriver initialized (device %d, fabric_domain=%s:%d)",
+            device_ordinal,
+            self._fabric_domain[0],
+            self._fabric_domain[1],
+        )
 
     def allocate_exportable(
         self,
         size: int,
         placement: Optional[MappingPlacement] = None,
     ) -> LocalAllocation:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """
+        Allocate HIP VMem memory exportable as a fabric handle.
+
+        If placement is supplied, the caller must already own a sufficiently
+        large, granularity-aligned VA range containing [placement.va,
+        placement.va + size).
+        """
+        self._check_initialized()
+        props = self._make_alloc_props()
+        granularity = self._get_granularity()
+        alloc_size = _round_up(size, granularity)
+
+        reserved_va = placement is None
+        mapped_va = int(placement.va) if placement is not None else 0
+        handle = hipMemGenericAllocationHandle_t()
+        mapped = False
+
+        try:
+            if reserved_va:
+                reserved = ctypes.c_void_p()
+                _hip_try(
+                    _hip.hipMemAddressReserve(ctypes.byref(reserved), alloc_size, granularity, None, 0),
+                    "hipMemAddressReserve",
+                )
+                if reserved.value is None:
+                    raise AmdFabricError("hipMemAddressReserve returned a null VA")
+                mapped_va = int(reserved.value)
+
+            _hip_try(
+                _hip.hipMemCreate(ctypes.byref(handle), alloc_size, ctypes.byref(props), 0),
+                "hipMemCreate",
+            )
+            _hip_try(
+                _hip.hipMemMap(ctypes.c_void_p(mapped_va), alloc_size, 0, handle, 0),
+                "hipMemMap",
+            )
+            mapped = True
+            access_base, access_bytes = (
+                placement.access_range(alloc_size, cumulative=True)
+                if placement is not None
+                else (mapped_va, alloc_size)
+            )
+            self._mem_set_access(access_base, access_bytes)
+            return LocalAllocation(
+                va=mapped_va,
+                size=alloc_size,
+                handle=int(handle.value),
+                _va_owned=reserved_va,
+            )
+        except Exception:
+            steps: list[tuple[str, Callable[[], None]]] = []
+            if mapped:
+                steps.append(
+                    (
+                        "hipMemUnmap",
+                        lambda: _hip_try(
+                            _hip.hipMemUnmap(ctypes.c_void_p(mapped_va), alloc_size),
+                            "hipMemUnmap",
+                        ),
+                    )
+                )
+            if handle.value:
+                steps.append(
+                    (
+                        "hipMemRelease",
+                        lambda: _hip_try(
+                            _hip.hipMemRelease(hipMemGenericAllocationHandle_t(int(handle.value))),
+                            "hipMemRelease",
+                        ),
+                    )
+                )
+            if reserved_va and mapped_va:
+                steps.append(
+                    (
+                        "hipMemAddressFree",
+                        lambda: _hip_try(
+                            _hip.hipMemAddressFree(ctypes.c_void_p(mapped_va), alloc_size),
+                            "hipMemAddressFree",
+                        ),
+                    )
+                )
+            _cleanup_after_failure(*steps)
+            raise
 
     def export_handle(self, memory: ExportableMemory) -> bytes:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Export a 64-byte HIP fabric handle for a driver-created allocation."""
+        self._check_initialized()
+        if memory.allocation is None:
+            raise AmdFabricNotSupported("AMD fabric driver can only export driver-created VMM allocations")
+
+        raw = hipMemFabricHandle()
+        _hip_try(
+            _hip.hipMemExportToShareableHandle(
+                ctypes.byref(raw),
+                hipMemGenericAllocationHandle_t(int(memory.allocation.handle)),
+                hipMemHandleTypeFabric,
+                0,
+            ),
+            "hipMemExportToShareableHandle",
+        )
+        return bytes(raw.data)
+
+    def _import_handle(self, handle_bytes: bytes) -> int:
+        handle_bytes = _normalize_fabric_handle_bytes(handle_bytes)
+        raw = hipMemFabricHandle.from_buffer_copy(handle_bytes)
+        imported = hipMemGenericAllocationHandle_t()
+        _hip_try(
+            _hip.hipMemImportFromShareableHandle(
+                ctypes.byref(imported),
+                ctypes.byref(raw),
+                hipMemHandleTypeFabric,
+            ),
+            "hipMemImportFromShareableHandle",
+        )
+        if imported.value is None:
+            raise AmdFabricError("hipMemImportFromShareableHandle returned a null allocation handle")
+        return int(imported.value)
 
     def import_and_map(
         self,
@@ -46,16 +710,181 @@ class AmdFabricDriver(BaseDriver):
         size: int,
         placement: Optional[MappingPlacement] = None,
     ) -> PeerMapping:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Import a HIP fabric handle and map it into local VMM VA space."""
+        self._check_initialized()
+        imported_handle = self._import_handle(handle_bytes)
+
+        granularity = self._get_granularity()
+        va_owned = placement is None
+        mapped_va = int(placement.va) if placement is not None else 0
+        mapped = False
+        try:
+            if va_owned:
+                reserved = ctypes.c_void_p()
+                _hip_try(
+                    _hip.hipMemAddressReserve(ctypes.byref(reserved), size, granularity, None, 0),
+                    "hipMemAddressReserve",
+                )
+                if reserved.value is None:
+                    raise AmdFabricError("hipMemAddressReserve returned a null VA")
+                mapped_va = int(reserved.value)
+            _hip_try(
+                _hip.hipMemMap(
+                    ctypes.c_void_p(mapped_va),
+                    size,
+                    0,
+                    hipMemGenericAllocationHandle_t(imported_handle),
+                    0,
+                ),
+                "hipMemMap",
+            )
+            mapped = True
+            access_base, access_bytes = (
+                placement.access_range(size, cumulative=True) if placement is not None else (mapped_va, size)
+            )
+            self._mem_set_access(access_base, access_bytes)
+        except Exception:
+            steps: list[tuple[str, Callable[[], None]]] = []
+            if mapped:
+                steps.append(
+                    (
+                        "hipMemUnmap",
+                        lambda: _hip_try(
+                            _hip.hipMemUnmap(ctypes.c_void_p(mapped_va), size),
+                            "hipMemUnmap",
+                        ),
+                    )
+                )
+            steps.append(
+                (
+                    "hipMemRelease",
+                    lambda: _hip_try(
+                        _hip.hipMemRelease(hipMemGenericAllocationHandle_t(imported_handle)),
+                        "hipMemRelease",
+                    ),
+                )
+            )
+            if va_owned and mapped_va:
+                steps.append(
+                    (
+                        "hipMemAddressFree",
+                        lambda: _hip_try(
+                            _hip.hipMemAddressFree(ctypes.c_void_p(mapped_va), size),
+                            "hipMemAddressFree",
+                        ),
+                    )
+                )
+            _cleanup_after_failure(*steps)
+            raise
+
+        tag = "driver_va" if va_owned else "caller_va"
+        return PeerMapping(
+            peer_rank=peer_rank,
+            transport=InterconnectLevel.INTRA_RACK_FABRIC,
+            remote_va=mapped_va,
+            size=size,
+            _driver_handle=(tag, imported_handle),
+        )
 
     def cleanup(self, target: LocalAllocation | PeerMapping) -> None:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Release a local HIP fabric allocation or imported HIP fabric mapping."""
+        if isinstance(target, LocalAllocation):
+            self._cleanup_local(target)
+            return
+        if isinstance(target, PeerMapping):
+            self._cleanup_import(target)
+            return
+        raise AmdFabricError(f"Unsupported cleanup target: {type(target).__name__}")
+
+    def _cleanup_import(self, mapping: PeerMapping) -> None:
+        """Unmap, release, and conditionally free an imported HIP fabric mapping."""
+        self._check_initialized()
+        if isinstance(mapping._driver_handle, tuple) and len(mapping._driver_handle) == 2:
+            tag, imported_handle = mapping._driver_handle
+        else:
+            tag = "driver_va"
+            imported_handle = mapping._driver_handle
+
+        steps: list[tuple[str, Callable[[], None]]] = [
+            (
+                "hipMemUnmap",
+                lambda: _hip_try(
+                    _hip.hipMemUnmap(ctypes.c_void_p(mapping.remote_va), mapping.size),
+                    "hipMemUnmap",
+                ),
+            ),
+            (
+                "hipMemRelease",
+                lambda: _hip_try(
+                    _hip.hipMemRelease(hipMemGenericAllocationHandle_t(int(imported_handle))),
+                    "hipMemRelease",
+                ),
+            ),
+        ]
+        if tag == "driver_va":
+            steps.append(
+                (
+                    "hipMemAddressFree",
+                    lambda: _hip_try(
+                        _hip.hipMemAddressFree(ctypes.c_void_p(mapping.remote_va), mapping.size),
+                        "hipMemAddressFree",
+                    ),
+                )
+            )
+        _run_cleanup_steps(*steps)
+
+    def _cleanup_local(self, allocation: LocalAllocation) -> None:
+        """Unmap, release, and conditionally free a local HIP fabric allocation."""
+        self._check_initialized()
+        steps: list[tuple[str, Callable[[], None]]] = [
+            (
+                "hipMemUnmap",
+                lambda: _hip_try(
+                    _hip.hipMemUnmap(ctypes.c_void_p(allocation.va), allocation.size),
+                    "hipMemUnmap",
+                ),
+            ),
+            (
+                "hipMemRelease",
+                lambda: _hip_try(
+                    _hip.hipMemRelease(hipMemGenericAllocationHandle_t(int(allocation.handle))),
+                    "hipMemRelease",
+                ),
+            ),
+        ]
+        if allocation._va_owned:
+            steps.append(
+                (
+                    "hipMemAddressFree",
+                    lambda: _hip_try(
+                        _hip.hipMemAddressFree(ctypes.c_void_p(allocation.va), allocation.size),
+                        "hipMemAddressFree",
+                    ),
+                )
+            )
+        _run_cleanup_steps(*steps)
 
     def get_minimum_granularity(self) -> int:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Return the HIP VMM allocation granularity for this device."""
+        self._check_initialized()
+        return self._get_granularity()
 
     def reserve_va(self, size: int, alignment: int = 0) -> int:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Reserve a HIP virtual address range without backing memory."""
+        self._check_initialized()
+        if alignment == 0:
+            alignment = self._get_granularity()
+
+        reserved = ctypes.c_void_p()
+        _hip_try(
+            _hip.hipMemAddressReserve(ctypes.byref(reserved), size, alignment, None, 0),
+            "hipMemAddressReserve",
+        )
+        if reserved.value is None:
+            raise AmdFabricError("hipMemAddressReserve returned a null VA")
+        return int(reserved.value)
 
     def free_va(self, va: int, size: int) -> None:
-        raise DriverNotSupported(_NOT_IMPLEMENTED_MESSAGE)
+        """Free a HIP VA range previously returned by reserve_va."""
+        self._check_initialized()
+        _hip_try(_hip.hipMemAddressFree(ctypes.c_void_p(va), size), "hipMemAddressFree")

--- a/iris/host/distributed/topology.py
+++ b/iris/host/distributed/topology.py
@@ -58,7 +58,7 @@ class FabricInfo:
     GPU-to-GPU links (NVLink via NVSwitch, or xGMI) without RDMA.
 
     AMD mapping:
-        cluster_uuid  <->  ppod_id   (physical pod identifier, uint64)
+        cluster_uuid  <->  ppod_id   (physical pod identifier, 16 bytes)
         clique_id     <->  vpod_id   (virtual pod identifier, uint32)
 
     NVIDIA mapping:
@@ -223,6 +223,136 @@ def _get_amdsmi_handle_by_pci(pci_bus_id: str, all_handles=None):
 # Fabric info
 # ---------------------------------------------------------------------------
 
+_AMDSMI_UINT32_SENTINEL = 0xFFFFFFFF
+_AMDSMI_STATUS_SUCCESS = 0
+_AMDSMI_INIT_AMD_GPUS = 1 << 1
+_AMDSMI_PPOD_ID_BYTES = 16
+_AMDSMI_FABRIC_PPOD_SENTINEL = bytes([0x99] * _AMDSMI_PPOD_ID_BYTES)
+
+
+class _AmdSmiBdfBitfields(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("function_number", ctypes.c_uint64, 3),
+        ("device_number", ctypes.c_uint64, 5),
+        ("bus_number", ctypes.c_uint64, 8),
+        ("domain_number", ctypes.c_uint64, 48),
+    ]
+
+
+class _AmdSmiBdf(ctypes.Union):
+    _pack_ = 1
+    _fields_ = [
+        ("bdf", _AmdSmiBdfBitfields),
+        ("as_uint", ctypes.c_uint64),
+    ]
+
+
+class _AmdSmiFabricInfoV1(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("accelerator_id", ctypes.c_uint32),
+        ("fabric_type", ctypes.c_uint32),
+        ("bandwidth", ctypes.c_uint32),
+        ("latency", ctypes.c_uint32),
+        ("ppod_id", ctypes.c_ubyte * _AMDSMI_PPOD_ID_BYTES),
+        ("ppod_size", ctypes.c_uint32),
+        ("vpod_id", ctypes.c_uint32),
+        ("vpod_size", ctypes.c_uint32),
+        ("vpod_active_accelerators", ctypes.c_uint32 * 32),
+        ("local_accelerators", ctypes.c_uint32 * 16),
+        ("addr_mode", ctypes.c_uint32),
+        ("accel_state", ctypes.c_uint32),
+    ]
+
+
+class _AmdSmiFabricInfoUnion(ctypes.Union):
+    _pack_ = 1
+    _fields_ = [("v1", _AmdSmiFabricInfoV1)]
+
+
+class _AmdSmiFabricInfoVer(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("version", ctypes.c_uint32),
+        ("fabric_version", _AmdSmiFabricInfoUnion),
+    ]
+
+
+class _AmdSmiFabricInfo(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("bdf", _AmdSmiBdf),
+        ("fabric_info", _AmdSmiFabricInfoVer),
+        ("reserved", ctypes.c_uint32 * 15),
+        ("_padding", ctypes.c_ubyte * 4),
+    ]
+
+
+_PCI_BDF_RE = re.compile(r"([0-9a-fA-F]+):([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-7])")
+
+
+def _amdsmi_bdf_from_pci_bus_id(pci_bus_id: str) -> _AmdSmiBdf:
+    match = _PCI_BDF_RE.search(pci_bus_id.strip())
+    if match is None:
+        raise ValueError(f"Unable to parse PCI bus ID: {pci_bus_id!r}")
+
+    domain = int(match.group(1), 16)
+    bus = int(match.group(2), 16)
+    device = int(match.group(3), 16)
+    function = int(match.group(4), 16)
+
+    bdf = _AmdSmiBdf()
+    bdf.as_uint = (domain << 16) | (bus << 8) | (device << 3) | function
+    return bdf
+
+
+def _amd_ppod_id_to_hex(ppod_id: Any) -> str:
+    """Normalize a 16-byte AMDSMI ppod_id value to the FabricInfo cluster_uuid string."""
+    if ppod_id is None:
+        return ""
+
+    try:
+        if isinstance(ppod_id, memoryview):
+            data = ppod_id.tobytes()
+        else:
+            data = bytes(ppod_id)
+    except (TypeError, ValueError):
+        try:
+            data = bytes(int(x) & 0xFF for x in ppod_id)
+        except Exception:
+            return ""
+
+    if len(data) != _AMDSMI_PPOD_ID_BYTES:
+        return ""
+    if set(data) <= {0} or set(data) <= {0xFF} or data == _AMDSMI_FABRIC_PPOD_SENTINEL:
+        return ""
+    return data.hex()
+
+
+def _amd_fabric_info_from_raw(raw: Any) -> FabricInfo:
+    """Convert an AMDSMI fabric-info dict/object into FabricInfo."""
+    if raw is None:
+        return FabricInfo()
+
+    if isinstance(raw, dict):
+        ppod_id = raw.get("ppod_id")
+        vpod_id = raw.get("vpod_id", 0)
+    else:
+        ppod_id = getattr(raw, "ppod_id", None)
+        vpod_id = getattr(raw, "vpod_id", 0)
+
+    try:
+        clique_id = int(vpod_id)
+    except (TypeError, ValueError):
+        return FabricInfo()
+
+    cluster_uuid = _amd_ppod_id_to_hex(ppod_id)
+    if not cluster_uuid or clique_id == _AMDSMI_UINT32_SENTINEL:
+        return FabricInfo()
+
+    return FabricInfo(cluster_uuid=cluster_uuid, clique_id=clique_id)
+
 
 def _amd_get_gpu_fabric_info(gpu_id: int, pci_bus_id: str = "") -> FabricInfo:
     """
@@ -239,7 +369,73 @@ def _amd_get_gpu_fabric_info(gpu_id: int, pci_bus_id: str = "") -> FabricInfo:
         FabricInfo with cluster_uuid = hex(ppod_id), clique_id = vpod_id.
         Returns empty FabricInfo if the call fails or is not available.
     """
-    # Default placeholder: no fabric info available (single-node behavior)
+    if not pci_bus_id or pci_bus_id == "unknown":
+        logger.debug("No PCI bus ID available for AMD fabric info query on GPU %d", gpu_id)
+        return FabricInfo()
+
+    try:
+        amdsmi = None
+        for amdsmi_path in (
+            ctypes.util.find_library("amd_smi"),
+            "libamd_smi.so",
+            "/opt/rocm/lib/libamd_smi.so",
+        ):
+            if not amdsmi_path:
+                continue
+            try:
+                amdsmi = ctypes.CDLL(amdsmi_path)
+                break
+            except OSError:
+                continue
+        if amdsmi is None:
+            logger.debug("libamd_smi.so not available, skipping AMD fabric info")
+            return FabricInfo()
+
+        amdsmi.amdsmi_init.argtypes = [ctypes.c_uint64]
+        amdsmi.amdsmi_init.restype = ctypes.c_uint32
+        amdsmi.amdsmi_get_processor_handle_from_bdf.argtypes = [
+            _AmdSmiBdf,
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        amdsmi.amdsmi_get_processor_handle_from_bdf.restype = ctypes.c_uint32
+        amdsmi.amdsmi_get_gpu_fabric_info.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(_AmdSmiFabricInfo),
+        ]
+        amdsmi.amdsmi_get_gpu_fabric_info.restype = ctypes.c_uint32
+
+        ret = int(amdsmi.amdsmi_init(_AMDSMI_INIT_AMD_GPUS))
+        if ret != _AMDSMI_STATUS_SUCCESS:
+            logger.debug("amdsmi_init() failed for AMD fabric info query with status %d", ret)
+            return FabricInfo()
+
+        processor = ctypes.c_void_p()
+        ret = int(
+            amdsmi.amdsmi_get_processor_handle_from_bdf(
+                _amdsmi_bdf_from_pci_bus_id(pci_bus_id),
+                ctypes.byref(processor),
+            )
+        )
+        if ret != _AMDSMI_STATUS_SUCCESS or processor.value is None:
+            logger.debug(
+                "amdsmi_get_processor_handle_from_bdf(%s) failed for GPU %d with status %d",
+                pci_bus_id,
+                gpu_id,
+                ret,
+            )
+            return FabricInfo()
+
+        raw = _AmdSmiFabricInfo()
+        ret = int(amdsmi.amdsmi_get_gpu_fabric_info(processor, ctypes.byref(raw)))
+        if ret != _AMDSMI_STATUS_SUCCESS:
+            logger.debug("amdsmi_get_gpu_fabric_info failed for GPU %d with status %d", gpu_id, ret)
+            return FabricInfo()
+
+        v1 = raw.fabric_info.fabric_version.v1
+        return _amd_fabric_info_from_raw({"ppod_id": bytes(v1.ppod_id), "vpod_id": int(v1.vpod_id)})
+    except Exception as e:
+        logger.debug("AMDSMI fabric info query failed for GPU %d: %s", gpu_id, e)
+
     return FabricInfo()
 
 

--- a/tests/unittests/test_drivers.py
+++ b/tests/unittests/test_drivers.py
@@ -20,7 +20,18 @@ from iris.drivers.base import (
     PeerMapping,
 )
 from iris.drivers.fabric import fabric_handle_bytes_to_tensor, fabric_tensor_to_handle_bytes
+from iris.drivers.fabric import amd as amd_driver_module
 from iris.drivers.fabric import nvidia as nvidia_driver_module
+from iris.drivers.fabric.amd import (
+    AMD_FABRIC_HANDLE_BYTES,
+    AmdFabricDriver,
+    AmdFabricError,
+    AmdFabricNotSupported,
+    _amdsmi_bdf_from_pci_bus_id,
+    _normalize_fabric_handle_bytes as _normalize_amd_fabric_handle_bytes,
+    _round_up as _amd_round_up,
+    _valid_fabric_domain,
+)
 from iris.drivers.fabric.nvidia import (
     CudaFabricError,
     CudaFabricNotSupported,
@@ -36,6 +47,10 @@ class TestExceptions:
     def test_cuda_fabric_error_uses_driver_error_hierarchy(self):
         assert issubclass(CudaFabricError, DriverError)
         assert issubclass(CudaFabricNotSupported, DriverNotSupported)
+
+    def test_amd_fabric_error_uses_driver_error_hierarchy(self):
+        assert issubclass(AmdFabricError, DriverError)
+        assert issubclass(AmdFabricNotSupported, DriverNotSupported)
 
 
 class TestFabricHandleSerialization:
@@ -88,6 +103,147 @@ class TestNvidiaFabricHelpers:
 
         with pytest.raises(CudaFabricError, match="Unable to convert"):
             _normalize_fabric_handle_bytes(Unconvertible())
+
+
+class TestAmdFabricHelpers:
+    def test_round_up(self):
+        assert _amd_round_up(1, 64) == 64
+        assert _amd_round_up(64, 64) == 64
+        assert _amd_round_up(65, 64) == 128
+
+    def test_round_up_rejects_nonpositive_granularity(self):
+        with pytest.raises(ValueError, match="granularity must be > 0"):
+            _amd_round_up(1, 0)
+
+    def test_normalize_fabric_handle_bytes(self):
+        original = bytes(range(AMD_FABRIC_HANDLE_BYTES))
+        assert _normalize_amd_fabric_handle_bytes(original) == original
+        assert _normalize_amd_fabric_handle_bytes(bytearray(original)) == original
+        assert _normalize_amd_fabric_handle_bytes(memoryview(original)) == original
+        tensor = torch.tensor(list(original), dtype=torch.uint8)
+        assert _normalize_amd_fabric_handle_bytes(tensor) == original
+
+    def test_normalize_fabric_handle_bytes_rejects_wrong_size(self):
+        with pytest.raises(AmdFabricError, match="expected 64 bytes"):
+            _normalize_amd_fabric_handle_bytes(b"\x00" * 8)
+
+    def test_amdsmi_bdf_from_pci_bus_id(self):
+        bdf = _amdsmi_bdf_from_pci_bus_id("GPU 0000:41:00.0")
+        assert bdf.as_uint == 0x4100
+        assert bdf.bdf.domain_number == 0
+        assert bdf.bdf.bus_number == 0x41
+        assert bdf.bdf.device_number == 0
+        assert bdf.bdf.function_number == 0
+
+    def test_amdsmi_bdf_from_pci_bus_id_rejects_invalid_string(self):
+        with pytest.raises(AmdFabricError, match="Unable to parse"):
+            _amdsmi_bdf_from_pci_bus_id("not-a-bdf")
+
+    def test_valid_fabric_domain_rejects_sentinels(self):
+        assert _valid_fabric_domain(bytes(range(16)), 7)
+        assert not _valid_fabric_domain(bytes(16), 7)
+        assert not _valid_fabric_domain(bytes([0x99] * 16), 7)
+        assert not _valid_fabric_domain(bytes(range(16)), 0xFFFFFFFF)
+
+
+class TestAmdFabricDriver:
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("allocate_exportable", (4096,)),
+            ("export_handle", (ExportableMemory(va=0, size=0, allocation=LocalAllocation(va=0, size=0, handle=0)),)),
+            ("import_and_map", (0, b"\x00" * AMD_FABRIC_HANDLE_BYTES, 4096)),
+            (
+                "cleanup",
+                (
+                    PeerMapping(
+                        peer_rank=0,
+                        transport=InterconnectLevel.INTRA_RACK_FABRIC,
+                        remote_va=0,
+                        size=0,
+                    ),
+                ),
+            ),
+            ("cleanup", (LocalAllocation(va=0, size=0, handle=0),)),
+        ],
+    )
+    def test_public_methods_require_initialize(self, method_name, args):
+        driver = AmdFabricDriver()
+        method = getattr(driver, method_name)
+        with pytest.raises(AmdFabricError, match="not initialized"):
+            method(*args)
+
+    def test_initialize_raises_when_no_hip_runtime(self, monkeypatch):
+        monkeypatch.setattr(amd_driver_module, "_hip", None)
+        driver = AmdFabricDriver()
+        with pytest.raises(AmdFabricNotSupported, match="libamdhip64.so.*not found"):
+            driver.initialize(0)
+
+    def test_cleanup_import_target_attempts_all_cleanup_steps(self, monkeypatch):
+        calls = []
+
+        class FakeHipDriver:
+            def hipMemUnmap(self, remote_va, size):
+                calls.append(("unmap", remote_va.value, size))
+                return 1
+
+            def hipMemRelease(self, handle):
+                calls.append(("release", handle.value))
+                return 0
+
+            def hipMemAddressFree(self, remote_va, size):
+                calls.append(("free", remote_va.value, size))
+                return 0
+
+        monkeypatch.setattr(amd_driver_module, "_hip", FakeHipDriver())
+        driver = AmdFabricDriver()
+        driver._initialized = True
+        mapping = PeerMapping(
+            peer_rank=2,
+            transport=InterconnectLevel.INTRA_RACK_FABRIC,
+            remote_va=0x2000,
+            size=4096,
+            _driver_handle=99,
+        )
+
+        with pytest.raises(AmdFabricError, match="hipMemUnmap"):
+            driver.cleanup(mapping)
+
+        assert calls == [
+            ("unmap", 0x2000, 4096),
+            ("release", 99),
+            ("free", 0x2000, 4096),
+        ]
+
+    def test_cleanup_local_target_attempts_all_cleanup_steps(self, monkeypatch):
+        calls = []
+
+        class FakeHipDriver:
+            def hipMemUnmap(self, va, size):
+                calls.append(("unmap", va.value, size))
+                return 1
+
+            def hipMemRelease(self, handle):
+                calls.append(("release", handle.value))
+                return 0
+
+            def hipMemAddressFree(self, va, size):
+                calls.append(("free", va.value, size))
+                return 0
+
+        monkeypatch.setattr(amd_driver_module, "_hip", FakeHipDriver())
+        driver = AmdFabricDriver()
+        driver._initialized = True
+        allocation = LocalAllocation(va=0x1000, size=8192, handle=77)
+
+        with pytest.raises(AmdFabricError, match="hipMemUnmap"):
+            driver.cleanup(allocation)
+
+        assert calls == [
+            ("unmap", 0x1000, 8192),
+            ("release", 77),
+            ("free", 0x1000, 8192),
+        ]
 
 
 class TestNvidiaFabricDriver:

--- a/tests/unittests/test_topology.py
+++ b/tests/unittests/test_topology.py
@@ -136,6 +136,7 @@ def _make_fake_amdsmi():
         "gpu0": "0000:41:00.0",
         "gpu1": "0000:42:00.0",
     }
+    module.fabric_by_handle = {}
 
     class AmdSmiLinkType:
         AMDSMI_LINK_TYPE_XGMI = "xgmi"
@@ -155,6 +156,15 @@ def _make_fake_amdsmi():
     def amdsmi_get_gpu_device_uuid(handle):
         return f"amd-{handle}"
 
+    def amdsmi_get_gpu_fabric_info(handle):
+        return module.fabric_by_handle.get(
+            handle,
+            {
+                "ppod_id": [0x99] * 16,
+                "vpod_id": 0xFFFFFFFF,
+            },
+        )
+
     def amdsmi_get_link_topology_nearest(handle, link_type):
         return {"processor_list": []}
 
@@ -164,6 +174,7 @@ def _make_fake_amdsmi():
     module.amdsmi_get_processor_handles = amdsmi_get_processor_handles
     module.amdsmi_get_gpu_device_bdf = amdsmi_get_gpu_device_bdf
     module.amdsmi_get_gpu_device_uuid = amdsmi_get_gpu_device_uuid
+    module.amdsmi_get_gpu_fabric_info = amdsmi_get_gpu_fabric_info
     module.amdsmi_get_link_topology_nearest = amdsmi_get_link_topology_nearest
 
     return module
@@ -424,6 +435,63 @@ class TestVendorLibraryLifecycle:
         fabric = topology._get_gpu_fabric_info(0, "nvidia", pci_bus_id="0000:41:00.0")
 
         assert fabric.domain_key == f"{'ab' * 16}:32766"
+
+    def test_amd_fabric_info_uses_direct_amdsmi_byref(self, monkeypatch):
+        class FakeAmdSmiFunction:
+            def __init__(self, callback):
+                self.callback = callback
+                self.restype = None
+                self.argtypes = None
+
+            def __call__(self, *args):
+                return self.callback(*args)
+
+        class FakeAmdSmiLib:
+            def __init__(self):
+                self.amdsmi_init = FakeAmdSmiFunction(self._init)
+                self.amdsmi_get_processor_handle_from_bdf = FakeAmdSmiFunction(self._get_handle)
+                self.amdsmi_get_gpu_fabric_info = FakeAmdSmiFunction(self._get_fabric_info)
+
+            def _init(self, flags):
+                assert flags == 1 << 1
+                return 0
+
+            def _get_handle(self, bdf, processor_ptr):
+                assert bdf.as_uint == 0x4100
+                processor_ptr._obj.value = 0xABCD
+                return 0
+
+            def _get_fabric_info(self, processor, info_ptr):
+                assert processor.value == 0xABCD
+                info = info_ptr._obj.fabric_info.fabric_version.v1
+                for idx, value in enumerate(bytes.fromhex("ab" * 16)):
+                    info.ppod_id[idx] = value
+                info.vpod_id = 9
+                return 0
+
+        monkeypatch.setattr(topology.ctypes.util, "find_library", lambda name: "fake-amdsmi")
+        monkeypatch.setattr(topology.ctypes, "CDLL", lambda path: FakeAmdSmiLib())
+
+        fabric = topology._get_gpu_fabric_info(0, "amd", pci_bus_id="0000:41:00.0")
+
+        assert fabric.domain_key == f"{'ab' * 16}:9"
+
+    def test_amd_fabric_info_requires_pci_bus_id(self):
+        fabric = topology._get_gpu_fabric_info(1, "amd")
+
+        assert fabric == FabricInfo()
+
+    def test_amd_fabric_info_rejects_sentinel_values(self):
+        assert topology._amd_fabric_info_from_raw({"ppod_id": [0x99] * 16, "vpod_id": 1}) == FabricInfo()
+        assert topology._amd_fabric_info_from_raw({"ppod_id": [0] * 16, "vpod_id": 1}) == FabricInfo()
+        assert topology._amd_fabric_info_from_raw({"ppod_id": [0xFF] * 16, "vpod_id": 1}) == FabricInfo()
+        assert topology._amd_fabric_info_from_raw({"ppod_id": [1] * 16, "vpod_id": 0xFFFFFFFF}) == FabricInfo()
+
+    def test_amd_fabric_info_rejects_non_16_byte_ppod(self):
+        assert topology._amd_fabric_info_from_raw({"ppod_id": 0x1234, "vpod_id": 5}) == FabricInfo()
+        assert topology._amd_fabric_info_from_raw({"ppod_id": "not-hex", "vpod_id": 1}) == FabricInfo()
+        assert topology._amd_fabric_info_from_raw({"ppod_id": [1] * 8, "vpod_id": 5}) == FabricInfo()
+        assert topology._amd_fabric_info_from_raw({"ppod_id": [1] * 17, "vpod_id": 5}) == FabricInfo()
 
     def test_missing_library_fallbacks_preserve_logs(self, monkeypatch, caplog):
         caplog.set_level(logging.DEBUG, logger="iris.topology")


### PR DESCRIPTION
## Motivation

Implement AMD Fabric driver and support the AMD fabric detection during topology discovery

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Unit tests + regression tests with MI355x 

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
